### PR TITLE
Allow content of rte to be styled with styled-components

### DIFF
--- a/packages/react-admin-rte/src/core/Rte.tsx
+++ b/packages/react-admin-rte/src/core/Rte.tsx
@@ -39,6 +39,7 @@ export interface IProps {
     value: EditorState;
     onChange: OnEditorStateChangeFn;
     options?: IOptions;
+    className?: string;
 }
 
 const defaultOptions: IRteOptions = {
@@ -64,7 +65,7 @@ export interface IRteRef {
     focus: () => void;
 }
 const Rte: React.RefForwardingComponent<any, IProps> = (props, ref) => {
-    const { value: editorState, onChange, options: passedOptions } = props;
+    const { value: editorState, onChange, options: passedOptions, className } = props;
     const editorRef = React.useRef<DraftJsEditor>(null);
     const editorWrapperRef = React.useRef<HTMLDivElement>(null);
     const options = passedOptions ? { ...defaultOptions, ...passedOptions } : defaultOptions; // merge default options with passed options
@@ -121,7 +122,7 @@ const Rte: React.RefForwardingComponent<any, IProps> = (props, ref) => {
     };
 
     return (
-        <sc.Root ref={editorWrapperRef}>
+        <sc.Root ref={editorWrapperRef} className={className}>
             <Controls editorRef={editorRef} editorState={editorState} setEditorState={onChange} options={options} />
             <sc.EditorWrapper>
                 <DraftJsEditor

--- a/packages/react-admin-stories/src/react-admin-rte/StyleContent.tsx
+++ b/packages/react-admin-stories/src/react-admin-rte/StyleContent.tsx
@@ -1,0 +1,36 @@
+import { storiesOf } from "@storybook/react";
+import { IRteRef, makeRteApi, Rte } from "@vivid-planet/react-admin-rte";
+import * as React from "react";
+import { exampleContent, PrintEditorState, RteLayout, useAutoFocus } from "./helper";
+import styled from "styled-components";
+
+const [useRteApi] = makeRteApi();
+
+const StyledRte = styled(Rte)`
+    div.DraftEditor-root {
+        font-family: monospace;
+        line-height: 2;
+    }
+    div.DraftEditor-editorContainer,
+    div.public-DraftEditor-content {
+    }
+`;
+
+function Story() {
+    const { editorState, setEditorState } = useRteApi({ defaultValue: JSON.stringify(exampleContent) }); // defaultValue is optional
+
+    // focus the editor to see the cursor immediately
+    const editorRef = React.useRef<IRteRef>();
+    useAutoFocus(editorRef);
+
+    return (
+        <>
+            <RteLayout>
+                <StyledRte value={editorState} onChange={setEditorState} ref={editorRef} />
+            </RteLayout>
+            <PrintEditorState editorState={editorState} />
+        </>
+    );
+}
+
+storiesOf("react-admin-rte", module).add("Rte, style Content", () => <Story />);


### PR DESCRIPTION
Erlaubt das Überschreiben von default styles mit styled-components:

https://styled-components.com/docs/basics#styling-any-component

```ts

import { Rte } from "@vivid-planet/react-admin-rte";
import styled from 'styled-components';


const StyledRte = styled(Rte)`
  div.DraftEditor-root {
        font-family: monospace;
        line-height: 2;
    }
`

```


