### PR TITLE
Render MenuItem in children of Route

### DIFF
--- a/packages/comet-admin/src/mui/menu/ItemRouterLink.tsx
+++ b/packages/comet-admin/src/mui/menu/ItemRouterLink.tsx
@@ -7,16 +7,13 @@ import { IMenuItemProps, MenuItem } from "./Item";
 interface IMenuItemRouterLinkProps {
     to: string;
 }
+
 export class MenuItemRouterLink extends React.Component<IMenuItemRouterLinkProps & IMenuItemProps & ListItemProps & LinkProps> {
     public render() {
         return (
-            <Route
-                path={this.props.to}
-                strict={false}
-                render={({ location, match }) => {
-                    return <MenuItem selected={!!match} component={Link} {...this.props} />;
-                }}
-            />
+            <Route path={this.props.to} strict={false}>
+                {({ match }) => <MenuItem selected={!!match} component={Link} {...this.props} />}
+            </Route>
         );
     }
 }


### PR DESCRIPTION
 MenuItem would not be rendered with the render function of Route.