### PR TITLE
chore: dependency-cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
         "@types/uuid": "^3.4.4",
         "@typescript-eslint/eslint-plugin": "^4.7.0",
         "@typescript-eslint/parser": "^4.7.0",
-        "apollo-link-rest": "^0.8.0-beta.0",
         "eslint": "^7.13.0",
         "eslint-config-prettier": "^6.15.0",
         "eslint-plugin-formatjs": "^2.9.3",

--- a/packages/comet-admin-color-picker/package.json
+++ b/packages/comet-admin-color-picker/package.json
@@ -19,7 +19,7 @@
         "@material-ui/core": "^4.1.3",
         "@material-ui/icons": "^4.2.1",
         "@material-ui/styles": "^4.1.2",
-        "@vivid-planet/comet-admin": "^0.0.0",
+        "@vivid-planet/comet-admin": "^1.0.0",
         "react": "^16.8",
         "react-final-form": "^6.3.1"
     },

--- a/packages/comet-admin-date-picker/package.json
+++ b/packages/comet-admin-date-picker/package.json
@@ -17,7 +17,7 @@
     },
     "peerDependencies": {
         "@material-ui/core": "^4.1.3",
-        "@vivid-planet/comet-admin": "^0.0.0",
+        "@vivid-planet/comet-admin": "^1.0.0",
         "react": "^16.8",
         "react-final-form": "^6.3.0",
         "react-intl": "^5.10.0"

--- a/packages/comet-admin-react-select/package.json
+++ b/packages/comet-admin-react-select/package.json
@@ -15,7 +15,7 @@
     "peerDependencies": {
         "@material-ui/core": "^4.1.3",
         "@material-ui/icons": "^4.2.1",
-        "@vivid-planet/comet-admin": "^0.0.0",
+        "@vivid-planet/comet-admin": "^1.0.0",
         "final-form": "^4.16.1",
         "react": "^16.8",
         "react-final-form": "^6.3.1",

--- a/packages/comet-admin-rte/package.json
+++ b/packages/comet-admin-rte/package.json
@@ -14,7 +14,7 @@
     "peerDependencies": {
         "@material-ui/core": "^4.1.3",
         "@material-ui/icons": "^4.2.1",
-        "@vivid-planet/comet-admin": "^0.0.0",
+        "@vivid-planet/comet-admin": "^1.0.0",
         "draft-js": "^0.11.4",
         "final-form": "^4.16.1",
         "immutable": "~3.7.4",

--- a/packages/comet-admin-stories/package.json
+++ b/packages/comet-admin-stories/package.json
@@ -15,7 +15,6 @@
         "@vivid-planet/comet-admin-rte": "*",
         "final-form": "^4.16.1",
         "graphql": "^15.4.0",
-        "graphql-tag": "^2.11.0",
         "react": "^16.8",
         "react-dom": "^16.8",
         "react-final-form": "^6.3.1",
@@ -23,6 +22,8 @@
         "styled-components": "^4.3.2"
     },
     "dependencies": {
+        "apollo-link-rest": "^0.8.0-beta.0",
+        "graphql-anywhere": "^4.2.7",
         "qs": "^6.9.1"
     },
     "devDependencies": {
@@ -40,13 +41,11 @@
         "@types/storybook-react-router": "^1.0.1",
         "@types/storybook__react": "^5.2.1",
         "@types/webpack": "^4.4.34",
-        "apollo-link-rest": "^0.8.0-beta.0",
         "babel-loader": "^8.0.6",
         "draft-js": "^0.11.5",
         "draft-js-export-html": "^1.4.1",
         "draft-js-export-markdown": "^1.4.0",
         "draft-js-import-markdown": "^1.4.0",
-        "graphql-anywhere": "^4.2.4",
         "immutable": "~3.7.4",
         "react-docgen-typescript-loader": "^3.1.0",
         "react-router": "^5.0.1",

--- a/packages/comet-admin/package.json
+++ b/packages/comet-admin/package.json
@@ -24,7 +24,6 @@
         "file-saver": "^2.0.2",
         "final-form": "^4.16.1",
         "graphql": "^15.4.0",
-        "graphql-tag": "^2.11.0",
         "history": "^4.10.1",
         "react": "^16.8",
         "react-dom": "^16.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8280,7 +8280,7 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
-graphql-anywhere@^4.2.4:
+graphql-anywhere@^4.2.7:
   version "4.2.7"
   resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-4.2.7.tgz#c06fb40b1d62b39470c80e3731478dbbef060067"
   integrity sha512-fJHvVywWVWjiHuPIMs16Nfjf4zdQUwSO1LKycwBJCWIPeoeQ8LqXK2BgYoZAHkhKEFktZZeYyzS4o/uIUG0z5A==


### PR DESCRIPTION
- apollo-link-rest is only used in comet-admin-stories and therefore moved
- peer dependency errors (e.g. `@vivid-planet/comet-admin-color-picker@1.0.0" has incorrect peer dependency "@vivid-planet/comet-admin@^0.0.0"`) fixed
-  graphql-tag is included in @apollo/client and therefore not needed anymore (see: https://www.apollographql.com/docs/react/migrating/apollo-client-3-migration/#graphql-tag)

on the long run we should consider removing apollo-link-rest from stories as well.