### PR TITLE
Fix ability to open temporary menu

### DIFF
--- a/packages/comet-admin/src/mui/menu/Menu.tsx
+++ b/packages/comet-admin/src/mui/menu/Menu.tsx
@@ -27,7 +27,9 @@ const Menu = ({ classes, children, permanentMenuMinWidth: passedPermanentMenuMin
         if (variant === "temporary" && open) {
             toggleOpen();
         }
-    }, [open, toggleOpen, variant]);
+        // useEffect dependencies need to stay empty, because the function should only be called on first render.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     React.useEffect(() => {
         return history.listen(() => {


### PR DESCRIPTION
The temporary menu should only be toggled (closed) once, when the component is rendered for the first time.
Adding dependencies to the useEffect function would cause the menu to close immediately, eg. when the menu is opened.