### PR TITLE
docs: add migration guide for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This version ist the first stable version.
 ### Highlights
 
 -   Renamed from react-admin to comet-admin (!!!)
--   Made comet-admin translateable with react-intl
+-   Made comet-admin translatable with react-intl
 -   Updated apollo
 
 ### Incompatible Changes
@@ -22,4 +22,96 @@ This version ist the first stable version.
 -   FinalForm wrappers (e.g. Checkbox, Input, ...) are now prefixed with FinalForm
 
 ### Internal Changes
+
 -   Switched form TSLint to ESLint
+
+### Migration Guide
+
+Clone this repository into your project repository. If you have a monorepo, you have to clone it into the right subfolder.
+
+An example can be found [here](https://github.com/vivid-planet/comet-admin-starter/pull/36).
+
+**Package Renaming**
+
+Automatic migrations using codeshift are available (use -d for dry-run):
+
+```
+npx jscodeshift --extensions=ts --parser=ts -t comet-admin/codemods/1.0.0/package-renames.ts src/
+npx jscodeshift --extensions=tsx --parser=tsx -t comet-admin/codemods/1.0.0/package-renames.ts src/
+```
+
+**Styled Components**
+
+Automatic migrations using codeshift are available (use -d for dry-run):
+
+```
+npx jscodeshift --extensions=ts --parser=ts -t comet-admin/codemods/1.0.0/styled-components.ts src/
+npx jscodeshift --extensions=tsx --parser=tsx -t comet-admin/codemods/1.0.0/styled-components.ts src/
+```
+
+**Apollo-Client**
+
+Detailed instructions can be found [here](https://www.apollographql.com/docs/react/migrating/apollo-client-3-migration). Automatic migrations using codeshift are available (use -d for dry-run):
+
+```
+git clone https://github.com/apollographql/apollo-client.git
+npx jscodeshift -t apollo-client/codemods/ac2-to-ac3/imports.js --extensions ts --parser ts src/
+npx jscodeshift -t apollo-client/codemods/ac2-to-ac3/imports.js --extensions tsx --parser tsx src/
+```
+
+**Component-Renames**
+
+FinalForm fields are now prefixed with FinalForm. Automatic migrations using codeshift are available (use -d for dry-run):
+
+```
+npx jscodeshift --extensions=ts --parser=ts -t comet-admin/codemods/1.0.0/component-renames.ts src/
+npx jscodeshift --extensions=tsx --parser=tsx -t comet-admin/codemods/1.0.0/component-renames.ts src/
+```
+
+**FormatLocalized**
+
+`FormatLocalized` has been removed in favor of `FormattedDate` and `FormattedTime` of react-intl. An example migration can look like this:
+
+Before:
+
+```
+<FormatLocalized date={parseISO(publishDate)} format="dd.MM.yyyy - HH:mm" />
+```
+
+After:
+
+```
+<FormattedDate value={date} day="2-digit" month="2-digit" year="numeric" />
+{" - "}
+<FormattedTime value={date} />
+```
+
+As an alternative, FormatLocalized can be created inside the project by using:
+
+```
+import { format } from "date-fns";
+import * as React from "react";
+import { useIntl } from "react-intl";
+
+interface IProps {
+    format: string;
+    date: Date | number;
+}
+export const FormatLocalized: React.FunctionComponent<IProps> = ({ date, format: formatString }) => {
+    const intl = useIntl();
+    const locale = intl.locale;
+    return <>{format(date, formatString, { locale })}</>;
+};
+```
+
+However, imports need to be adjusted manually.
+
+**Internationalization**
+
+Strings are now prepared for internationalization. The default language is switched from German to English. A sample setup can be found [here](https://github.com/vivid-planet/comet-admin-starter/pull/36).
+
+**Fix Eslint Errors**
+
+```
+npx eslint --ext .ts,.tsx,.js,.jsx,.json,.md --fix src/
+```

--- a/codemods/1.0.0/component-renames.ts
+++ b/codemods/1.0.0/component-renames.ts
@@ -1,0 +1,50 @@
+import { Transform } from "jscodeshift";
+
+const renameMap = {
+    Checkbox: "FinalFormCheckbox",
+    Input: "FinalFormInput",
+    Radio: "FinalFormRadio",
+    Switch: "FinalFormSwitch",
+    ReactSelect: "FinalFormReactSelect",
+    ReactSelectAsync: "FinalFormReactSelectAsync",
+    ReactSelectCreatable: "FinalFormReactSelectCreatable",
+    ReactSelectAsyncCreateable: "FinalFormReactSelectAsyncCreateable",
+    ReactSelectStaticOptions: "FinalFormReactSelectStaticOptions",
+    TextField: "FinalFormTextField",
+    ColorPicker: "FinalFormColorPicker",
+    DatePicker: "FinalFormDatePicker",
+    DateRangePicker: "FinalFormDateRangePicker",
+};
+
+const transform: Transform = (file, api, options) => {
+    const j = api.jscodeshift;
+
+    // Convert the entire file source into a collection of nodes paths.
+    const root = j(file.source);
+
+    for (const candidateElement of Object.keys(renameMap)) {
+        const touched = {};
+        root.findJSXElements(candidateElement).forEach((element, i) => {
+            // Check if we can find an import from comet-admin and rename that as well
+            root.find(j.ImportDeclaration).forEach((imp) => {
+                if (imp.value.source.value === "@vivid-planet/comet-admin") {
+                    imp.value.specifiers.forEach((specifier) => {
+                        if (specifier.local.name === candidateElement) {
+                            specifier.local.name = renameMap[candidateElement];
+                            touched[candidateElement] = true;
+                        }
+                    });
+                }
+            });
+
+            // if we found no import, it is probably not a elemnt w
+            if (touched[candidateElement]) {
+                element.value.openingElement.name.name = renameMap[candidateElement];
+            }
+        });
+    }
+
+    return root.toSource();
+};
+
+export default transform;

--- a/codemods/1.0.0/package-renames.ts
+++ b/codemods/1.0.0/package-renames.ts
@@ -1,0 +1,33 @@
+import { Transform } from "jscodeshift";
+
+const renameMap: { [key: string]: string } = {
+    "@vivid-planet/react-admin-core": "@vivid-planet/comet-admin",
+    "@vivid-planet/fetch-provider": "@vivid-planet/comet-admin",
+    "@vivid-planet/file-icons": "@vivid-planet/comet-admin",
+    "@vivid-planet/react-admin-final-form-material-ui": "@vivid-planet/comet-admin",
+    "@vivid-planet/react-admin-form": "@vivid-planet/comet-admin",
+    "@vivid-planet/react-admin-layout": "@vivid-planet/comet-admin",
+    "@vivid-planet/react-select": "@vivid-planet/comet-admin-react-select",
+    "@vivid-planet/react-admin-date-picker": "@vivid-planet/comet-admin-date-picker",
+    "@vivid-planet/react-admin-color-picker": "@vivid-planet/comet-admin-color-picker",
+    "@vivid-planet/react-admin-rte": "@vivid-planet/comet-admin-rte",
+};
+
+const transform: Transform = (file, api, options) => {
+    const j = api.jscodeshift;
+
+    // Convert the entire file source into a collection of nodes paths.
+    const root = j(file.source);
+
+    root.find(j.ImportDeclaration).forEach((imp) => {
+        const source = imp.value.source.value as string;
+        const key = Object.keys(renameMap).find((key) => source.startsWith(key));
+        if (key) {
+            imp.value.source.value = renameMap[key];
+        }
+    });
+
+    return root.toSource();
+};
+
+export default transform;

--- a/codemods/1.0.0/styled-components.ts
+++ b/codemods/1.0.0/styled-components.ts
@@ -1,0 +1,31 @@
+import { Transform } from "jscodeshift";
+
+const transform: Transform = (file, api, options) => {
+    const j = api.jscodeshift;
+
+    // Convert the entire file source into a collection of nodes paths.
+    const root = j(file.source);
+
+    const importsToInsert = [];
+    root.find(j.ImportDeclaration, { source: { value: "@vivid-planet/react-admin-mui" } }).forEach((imp) => {
+        imp.value.specifiers.forEach((specifier) => {
+            const name = specifier.local.name;
+            if (name === "styled") {
+                importsToInsert.push(j.importDefaultSpecifier(j.identifier("styled")));
+            } else if (name === "css") {
+                importsToInsert.push(j.importSpecifier(j.identifier("css")));
+            }
+        });
+    });
+
+    const removedImports = root.find(j.ImportDeclaration, { source: { value: "@vivid-planet/react-admin-mui" } }).remove();
+    if (removedImports.length > 0) {
+        root.find(j.Declaration)
+            .at(0)
+            .insertBefore(j.importDeclaration(importsToInsert, j.stringLiteral("styled-components"), "value"));
+    }
+
+    return root.toSource();
+};
+
+export default transform;

--- a/packages/comet-admin-stories/src/react-admin-core/Intl.tsx
+++ b/packages/comet-admin-stories/src/react-admin-core/Intl.tsx
@@ -1,0 +1,18 @@
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import { FormattedDate, FormattedTime } from "react-intl";
+
+import { apolloStoryDecorator } from "../apollo-story.decorator";
+
+function Story() {
+    const date = new Date();
+    return (
+        <>
+            <FormattedDate value={date} weekday="short" day="2-digit" month="2-digit" year="numeric" /> - <FormattedTime value={date} />
+        </>
+    );
+}
+
+storiesOf("react-intl", module)
+    .addDecorator(apolloStoryDecorator())
+    .add("FormatLocalized", () => <Story />);


### PR DESCRIPTION
- adds Migration Guide for v1.0.0
- adds Story for using React-Intl as a substitute for date-fns