### PR TITLE
Deprecate RouterTab tabLabel prop

### DIFF
--- a/packages/admin/src/RouterTabs.tsx
+++ b/packages/admin/src/RouterTabs.tsx
@@ -10,12 +10,15 @@ import { StackApiContext, StackBreadcrumb, StackSwitchApiContext } from "./stack
 
 interface ITabProps extends TabProps {
     path: string;
-    label: string;
+    label: React.ReactNode;
     forceRender?: boolean;
+    /**
+     * @deprecated Use label instead.
+     */
     tabLabel?: React.ReactNode;
     children: React.ReactNode;
 }
-export const RouterTab: React.SFC<ITabProps> = () => null;
+export const RouterTab: React.FC<ITabProps> = () => null;
 
 function TabContainer(props: any) {
     return (

--- a/packages/admin/src/stack/Breadcrumb.tsx
+++ b/packages/admin/src/stack/Breadcrumb.tsx
@@ -5,7 +5,7 @@ const UUID = require("uuid");
 
 interface IProps {
     url: string;
-    title: string;
+    title: React.ReactNode;
     invisible?: boolean;
     ignoreParentId?: boolean;
 }


### PR DESCRIPTION
The `tabLabel` prop was presumably added to support setting a `ReactNode` as the tab label. However, the Material-UI Tab component actually use `ReactNode` as the `label` prop. Changing the `RouterTab`'s `label` prop from `string` to `ReactNode` therefore reduces the need for an additional prop.