### PR TITLE
Make controls for RTE sticky

### DIFF
--- a/packages/admin-rte/src/core/Controls/Toolbar.sc.ts
+++ b/packages/admin-rte/src/core/Controls/Toolbar.sc.ts
@@ -1,8 +1,12 @@
 import styled from "styled-components";
 
 export const Root = styled.div`
+    position: sticky;
+    top: 0;
+    z-index: 2;
     display: flex;
     flex-wrap: wrap;
+    border-top: 1px solid ${({ theme }) => theme.rte.colors.border};
     background-color: ${({ theme }) => theme.rte.colors.toolbarBackground};
     padding-left: 6px;
     padding-right: 6px;

--- a/packages/admin-rte/src/core/Rte.sc.ts
+++ b/packages/admin-rte/src/core/Rte.sc.ts
@@ -2,6 +2,7 @@ import styled, { css } from "styled-components";
 
 export const Root = styled.div`
     border: 1px solid ${({ theme }) => theme.rte.colors.border};
+    border-top-width: 0;
 `;
 
 export const EditorWrapper = styled.div<{ disabled?: boolean }>`
@@ -12,6 +13,7 @@ export const EditorWrapper = styled.div<{ disabled?: boolean }>`
                 color: ${theme.palette.text.disabled};
             }
         `};
+
     .public-DraftEditor-content {
         min-height: 240px;
         padding: 20px;


### PR DESCRIPTION
Prevents controls from disappearing when there is lots of text.