### PR TITLE
Remove tab-index from clear-button

### DIFF
--- a/packages/admin/src/common/ClearInputButton.tsx
+++ b/packages/admin/src/common/ClearInputButton.tsx
@@ -34,7 +34,7 @@ const ClearButton: React.FC<WithStyles<typeof styles, true> & ClearInputButtonTh
     ...otherButtonBaseProps
 }) => {
     return (
-        <ButtonBase classes={{ root: classes.root, disabled: classes.disabled }} disabled={disabled} {...otherButtonBaseProps}>
+        <ButtonBase classes={{ root: classes.root, disabled: classes.disabled }} disabled={disabled} tabIndex={-1} {...otherButtonBaseProps}>
             {icon ? icon(disabled) : <ClearIcon className={classes.defaultIcon} fontSize={"small"} color={disabled ? "disabled" : "action"} />}
         </ButtonBase>
     );


### PR DESCRIPTION
This makes it easier and more consistent to move between inputs using tab.