### PR TITLE
Pass innerRef to sc.TableBodyRow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. This projec
 
 ## Next
 
+### Bugfixes
+
+-   Pass `innerRef` from `TableBodyRow` to `sc.TableBodyRow`
+
 ### Internal Changes
 
 -   The `styled-components` peer dependency has been changed to `^4.0.0 || ^5.0.0` to include v5.

--- a/packages/admin/src/table/Table.tsx
+++ b/packages/admin/src/table/Table.tsx
@@ -16,7 +16,7 @@ import { safeColumnGet } from "./safeColumnGet";
 import * as sc from "./Table.sc";
 import { ISortApi, SortDirection } from "./useTableQuerySort";
 
-export function TableBodyRow({ innerRef, ...props }: sc.ITableBodyRowProps) {
+export function TableBodyRow({ ...props }: sc.ITableBodyRowProps) {
     return <sc.TableBodyRow {...props} />;
 }
 export interface ITableHeadRowProps<TRow extends IRow> extends ITableHeadColumnsProps<TRow> {}

--- a/packages/admin/src/table/Table.tsx
+++ b/packages/admin/src/table/Table.tsx
@@ -16,7 +16,7 @@ import { safeColumnGet } from "./safeColumnGet";
 import * as sc from "./Table.sc";
 import { ISortApi, SortDirection } from "./useTableQuerySort";
 
-export function TableBodyRow({ ...props }: sc.ITableBodyRowProps) {
+export function TableBodyRow(props: sc.ITableBodyRowProps) {
     return <sc.TableBodyRow {...props} />;
 }
 export interface ITableHeadRowProps<TRow extends IRow> extends ITableHeadColumnsProps<TRow> {}


### PR DESCRIPTION
Pass `innerRef` to `sc.TableBodyRow`. Before this change the `innerRef` wasn't used in any way.

I need to pass a ref in order to use the TableBodyRow as `DropTarget` in [react-dnd](https://react-dnd.github.io/react-dnd/docs/api/use-drop)