### PR TITLE
Fix too restrictive peer dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Next
+
+### Internal Changes
+
+-   The `styled-components` peer dependency has been changed to `^4.0.0 || ^5.0.0` to include v5.
+-   The `graphql` peer dependency has been changed to `^14.0.0 || ^15.0.0` to include v14.
+
 ## [1.2.0] - 23. Feb 2021
 
 ### Highlights

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-    "packages/**/*.{ts,tsx,js,jsx,json,css,scss,md}": "npm run lint",
+    "packages/**/*.{ts,tsx,js,jsx}": "npm run lint",
     "*": () => "npx prettier -c .",
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -24237,7 +24237,7 @@
                 "exceljs": "^3.4.0",
                 "file-saver": "^2.0.2",
                 "final-form": "^4.16.1",
-                "graphql": "^15.4.0",
+                "graphql": "^14.0.0 || ^15.0.0",
                 "history": "^4.10.1",
                 "react": "^16.8",
                 "react-dom": "^16.8",
@@ -24245,7 +24245,7 @@
                 "react-intl": "^5.10.0",
                 "react-router": "^5.1.2",
                 "react-router-dom": "^5.1.2",
-                "styled-components": "^4.3.2"
+                "styled-components": "^4.0.0 || ^5.0.0"
             }
         },
         "packages/admin-color-picker": {
@@ -24402,12 +24402,11 @@
                 "@material-ui/icons": "^4.2.1",
                 "@material-ui/styles": "^4.1.2",
                 "final-form": "^4.16.1",
-                "graphql": "^15.4.0",
                 "react": "^16.8",
                 "react-dom": "^16.8",
                 "react-final-form": "^6.3.1",
                 "react-intl": "^5.10.0",
-                "styled-components": "^4.3.2"
+                "styled-components": "^4.0.0 || ^5.0.0"
             }
         },
         "packages/admin-stories/node_modules/@types/react-router-dom": {

--- a/packages/admin-stories/package.json
+++ b/packages/admin-stories/package.json
@@ -14,12 +14,11 @@
         "@material-ui/icons": "^4.2.1",
         "@material-ui/styles": "^4.1.2",
         "final-form": "^4.16.1",
-        "graphql": "^15.4.0",
         "react": "^16.8",
         "react-dom": "^16.8",
         "react-final-form": "^6.3.1",
         "react-intl": "^5.10.0",
-        "styled-components": "^4.3.2"
+        "styled-components": "^4.0.0 || ^5.0.0"
     },
     "dependencies": {
         "apollo-link-rest": "^0.8.0-beta.0",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -23,7 +23,7 @@
         "exceljs": "^3.4.0",
         "file-saver": "^2.0.2",
         "final-form": "^4.16.1",
-        "graphql": "^15.4.0",
+        "graphql": "^14.0.0 || ^15.0.0",
         "history": "^4.10.1",
         "react": "^16.8",
         "react-dom": "^16.8",
@@ -31,7 +31,7 @@
         "react-intl": "^5.10.0",
         "react-router": "^5.1.2",
         "react-router-dom": "^5.1.2",
-        "styled-components": "^4.3.2"
+        "styled-components": "^4.0.0 || ^5.0.0"
     },
     "scripts": {
         "prebuild": "rimraf lib",


### PR DESCRIPTION
The peer dependencies for `graphql` and `styled-components` were too restrictive, which caused some issues with transitive peer dependencies. This change loosens the peer dependencies.