### PR TITLE
Change stack title to ReactNode

### DIFF
--- a/packages/admin-stories/src/admin/stack/StackReactNodeTitle.tsx
+++ b/packages/admin-stories/src/admin/stack/StackReactNodeTitle.tsx
@@ -1,0 +1,34 @@
+import { Stack, StackBreadcrumbsContainer, StackPage, StackPageTitle, useStackSwitch } from "@comet/admin";
+import { Button, Typography } from "@material-ui/core";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import StoryRouter from "storybook-react-router";
+import styled from "styled-components";
+
+const BreadcrumbsContainer = styled(StackBreadcrumbsContainer)`
+    border: 1px solid red;
+`;
+
+function Story() {
+    const [StackSwitch, api] = useStackSwitch();
+
+    return (
+        <Stack topLevelTitle={<Typography color="primary">Page 1</Typography>} components={{ breadcrumbsContainer: BreadcrumbsContainer }}>
+            <StackSwitch initialPage="page1">
+                <StackPage name="page1">
+                    <Typography variant="h1">Page 1</Typography>
+                    <Button onClick={() => api.activatePage("page2", "foo")}>To page 2</Button>
+                </StackPage>
+                <StackPage name="page2">
+                    <StackPageTitle title={<Typography color="secondary">Page 2</Typography>}>
+                        <Typography variant="h2">Page 2</Typography>
+                    </StackPageTitle>
+                </StackPage>
+            </StackSwitch>
+        </Stack>
+    );
+}
+
+storiesOf("@comet/admin/stack", module)
+    .addDecorator(StoryRouter())
+    .add("Stack with React.ReactNode title", () => <Story />);

--- a/packages/admin/src/mui/breadcrumbs/Breadcrumbs.tsx
+++ b/packages/admin/src/mui/breadcrumbs/Breadcrumbs.tsx
@@ -6,7 +6,7 @@ import { Link as RouterLink, LinkProps as RouterLinkProps } from "react-router-d
 export interface IBreadcrumbItem {
     id: string;
     url: string;
-    title: string;
+    title: React.ReactNode;
 }
 
 export interface IBreadcrumbProps {

--- a/packages/admin/src/stack/Api.tsx
+++ b/packages/admin/src/stack/Api.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
 export interface IStackApi {
-    addBreadcrumb: (id: string, parentId: string, url: string, title: string) => void;
-    updateBreadcrumb: (id: string, parentId: string, url: string, title: string) => void;
+    addBreadcrumb: (id: string, parentId: string, url: string, title: React.ReactNode) => void;
+    updateBreadcrumb: (id: string, parentId: string, url: string, title: React.ReactNode) => void;
     removeBreadcrumb: (id: string) => void;
     goBack: () => void;
     goAllBack: () => void;

--- a/packages/admin/src/stack/Breadcrumb.tsx
+++ b/packages/admin/src/stack/Breadcrumb.tsx
@@ -5,7 +5,7 @@ const UUID = require("uuid");
 
 interface IProps {
     url: string;
-    title: string;
+    title: React.ReactNode;
     invisible?: boolean;
     ignoreParentId?: boolean;
 }

--- a/packages/admin/src/stack/Page.tsx
+++ b/packages/admin/src/stack/Page.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 export interface IStackPageProps {
     name: string;
-    title?: string;
+    title?: React.ReactNode;
     children: ((id: string) => React.ReactNode) | React.ReactNode;
 }
 

--- a/packages/admin/src/stack/Stack.tsx
+++ b/packages/admin/src/stack/Stack.tsx
@@ -58,7 +58,7 @@ const sortByParentId = <TSortNode extends ISortNode>(nodes: TSortNode[]) => {
 };
 
 interface IProps {
-    topLevelTitle: string;
+    topLevelTitle: React.ReactNode;
     showBackButton?: boolean;
     showBreadcrumbs?: boolean;
     components?: {
@@ -69,7 +69,7 @@ interface IBreadcrumbItem {
     id: string;
     parentId: string;
     url: string;
-    title: string;
+    title: React.ReactNode;
     invisible: boolean;
 }
 interface ISwitchItem {
@@ -187,7 +187,7 @@ export class Stack extends React.Component<IProps, IState> {
         this.history.push(this.state.breadcrumbs[0].url);
     }
 
-    private addBreadcrumb(id: string, parentId: string, url: string, title: string, invisible: boolean) {
+    private addBreadcrumb(id: string, parentId: string, url: string, title: React.ReactNode, invisible: boolean) {
         this.setState((state) => {
             const breadcrumbs = [
                 ...state.breadcrumbs,
@@ -206,7 +206,7 @@ export class Stack extends React.Component<IProps, IState> {
         });
     }
 
-    private updateBreadcrumb(id: string, parentId: string, url: string, title: string, invisible: boolean) {
+    private updateBreadcrumb(id: string, parentId: string, url: string, title: React.ReactNode, invisible: boolean) {
         this.setState((state) => {
             const breadcrumbs = state.breadcrumbs.map((crumb) => {
                 return crumb.id === id ? { id, parentId, url, title, invisible } : crumb;

--- a/packages/admin/src/stack/StackPageTitle.tsx
+++ b/packages/admin/src/stack/StackPageTitle.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { StackSwitchApiContext } from "./Switch";
 
 interface IProps {
-    title?: string;
+    title?: React.ReactNode;
     children: React.ReactNode;
 }
 

--- a/packages/admin/src/stack/Switch.tsx
+++ b/packages/admin/src/stack/Switch.tsx
@@ -8,15 +8,15 @@ const UUID = require("uuid");
 
 interface IProps {
     initialPage?: string;
-    title?: string;
+    title?: React.ReactNode;
     children: Array<React.ReactElement<IStackPageProps>>;
 }
 
 export const StackSwitchApiContext = React.createContext<IStackSwitchApi>({
-    activatePage: (pageName: string, payload: string, subUrl?: string) => {
+    activatePage: () => {
         return;
     },
-    updatePageBreadcrumbTitle: (title?: string) => {
+    updatePageBreadcrumbTitle: () => {
         return;
     },
 });
@@ -26,7 +26,7 @@ export function useStackSwitchApi() {
 
 export interface IStackSwitchApi {
     activatePage: (pageName: string, payload: string, subUrl?: string) => void;
-    updatePageBreadcrumbTitle: (title?: string) => void;
+    updatePageBreadcrumbTitle: (title?: React.ReactNode) => void;
     id?: string;
 }
 interface IRouteParams {
@@ -49,7 +49,7 @@ export function useStackSwitch(): [React.ComponentType<IProps>, IStackSwitchApi]
         activatePage: (pageName: string, payload: string, subUrl?: string) => {
             apiRef.current?.activatePage(pageName, payload, subUrl);
         },
-        updatePageBreadcrumbTitle: (title?: string) => {
+        updatePageBreadcrumbTitle: (title?: React.ReactNode) => {
             apiRef.current?.updatePageBreadcrumbTitle(title);
         },
     };


### PR DESCRIPTION
Previously, the stack title could be defined using a string. This didn't work well with our internationalisation approach. This change changes the title prop to React.ReactNode to resolve the issue.