### PR TITLE
FinalForm - onAfterSubmit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Next
+
+### Feature
+
+-   add onAfterSubmit to FinalForm
+
 ## [1.3.0] - 4. March 2021
 
 This is a bugfix/maintenance release.

--- a/packages/admin-stories/src/admin/form/DisableAutoNavigation.tsx
+++ b/packages/admin-stories/src/admin/form/DisableAutoNavigation.tsx
@@ -3,7 +3,6 @@ import { Table } from "@comet/admin";
 import { Field, FinalForm, FinalFormInput, FormPaper } from "@comet/admin";
 import { IconButton, Typography } from "@material-ui/core";
 import { ArrowBack, Edit } from "@material-ui/icons";
-import { boolean } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
 import { Switch } from "react-router";
@@ -77,7 +76,7 @@ const SampleForm: React.FunctionComponent = () => {
         alert("Submit successful");
         return Promise.resolve();
     };
-    const enableAutoNavigation = boolean("Enable Auto Navigation", false);
+
     return (
         <>
             <Toolbar>
@@ -94,8 +93,14 @@ const SampleForm: React.FunctionComponent = () => {
                     <Typography>Sample Form</Typography>
                 </ToolbarItem>
             </Toolbar>
-            <Typography variant={"h3"}>Auto Navigation: {enableAutoNavigation ? "enabled" : "disabled"}</Typography>
-            <FinalForm mode={"edit"} onSubmit={onSubmit} autoNavigationEnabled={enableAutoNavigation}>
+
+            <FinalForm
+                mode={"edit"}
+                onSubmit={onSubmit}
+                onAfterSubmit={(values, form) => {
+                    form.reset(values); //Reset values to new values so dirty state is correct after submitting
+                }}
+            >
                 <FormPaper>
                     <Field label="Foo" name="foo" component={FinalFormInput} />
                 </FormPaper>

--- a/packages/admin-stories/src/admin/form/DisableAutoNavigation.tsx
+++ b/packages/admin-stories/src/admin/form/DisableAutoNavigation.tsx
@@ -1,0 +1,129 @@
+import { Stack, StackApiContext, StackPage, StackSwitch, StackSwitchApiContext } from "@comet/admin";
+import { Table } from "@comet/admin";
+import { Field, FinalForm, FinalFormInput, FormPaper } from "@comet/admin";
+import { IconButton, Typography } from "@material-ui/core";
+import { ArrowBack, Edit } from "@material-ui/icons";
+import { boolean } from "@storybook/addon-knobs";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import { Switch } from "react-router";
+import StoryRouter from "storybook-react-router";
+import styled from "styled-components";
+
+import { apolloStoryDecorator } from "../../apollo-story.decorator";
+export const Toolbar = styled.div`
+    height: 60px;
+    display: flex;
+    box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.1);
+    margin-bottom: 40px;
+`;
+
+export const ToolbarItem = styled.div`
+    :not(:last-child) {
+        border-right: 1px solid lightgray;
+    }
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    min-width: 60px;
+    padding: 0 20px;
+`;
+
+const SampleTable: React.FunctionComponent = () => {
+    const stackApi = React.useContext(StackSwitchApiContext);
+
+    return (
+        <>
+            <Toolbar>
+                <ToolbarItem>
+                    <Typography>Sample Table</Typography>
+                </ToolbarItem>
+            </Toolbar>
+            <Table
+                data={[
+                    { id: "1", name: "Lorem" },
+                    { id: "2", name: "ipsum" },
+                ]}
+                totalCount={2}
+                columns={[
+                    {
+                        name: "id",
+                        header: "id",
+                    },
+                    {
+                        name: "name",
+                        header: "Title",
+                    },
+                    {
+                        name: "actions",
+                        render: (recipe) => (
+                            <>
+                                <IconButton onClick={() => stackApi.activatePage("edit", recipe.id)}>
+                                    <Edit color={"primary"} />
+                                </IconButton>
+                            </>
+                        ),
+                    },
+                ]}
+            />
+        </>
+    );
+};
+
+const SampleForm: React.FunctionComponent = () => {
+    const stackApi = React.useContext(StackApiContext);
+
+    const onSubmit = async () => {
+        alert("Submit successful");
+        return Promise.resolve();
+    };
+    const enableAutoNavigation = boolean("Enable Auto Navigation", false);
+    return (
+        <>
+            <Toolbar>
+                <ToolbarItem>
+                    <IconButton
+                        onClick={() => {
+                            stackApi?.goBack();
+                        }}
+                    >
+                        <ArrowBack color={"primary"} />
+                    </IconButton>
+                </ToolbarItem>
+                <ToolbarItem>
+                    <Typography>Sample Form</Typography>
+                </ToolbarItem>
+            </Toolbar>
+            <Typography variant={"h3"}>Auto Navigation: {enableAutoNavigation ? "enabled" : "disabled"}</Typography>
+            <FinalForm mode={"edit"} onSubmit={onSubmit} autoNavigationEnabled={enableAutoNavigation}>
+                <FormPaper>
+                    <Field label="Foo" name="foo" component={FinalFormInput} />
+                </FormPaper>
+            </FinalForm>
+        </>
+    );
+};
+
+function Story() {
+    return (
+        <>
+            <Switch>
+                <Stack topLevelTitle={"Sample"} showBreadcrumbs={false}>
+                    <StackSwitch initialPage="table">
+                        <StackPage name="table">
+                            <SampleTable />
+                        </StackPage>
+                        <StackPage name="edit" title={"Edit"}>
+                            <SampleForm />
+                        </StackPage>
+                    </StackSwitch>
+                </Stack>
+            </Switch>
+        </>
+    );
+}
+
+storiesOf("@comet/admin/form", module)
+    .addDecorator(StoryRouter())
+    .addDecorator(apolloStoryDecorator())
+    .add("Disable Auto Navigation", () => <Story />);

--- a/packages/admin/src/FinalForm.tsx
+++ b/packages/admin/src/FinalForm.tsx
@@ -32,9 +32,13 @@ interface IProps<FormValues = AnyObject> extends FormProps<FormValues> {
 
     // override final-form onSubmit and remove callback as we don't support that (return pomise instead)
     onSubmit: (values: FormValues, form: FormApi<FormValues>) => SubmissionErrors | Promise<SubmissionErrors | undefined> | undefined | void;
+    autoNavigationEnabled?: boolean;
 }
 
-export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
+export function FinalForm<FormValues = AnyObject>({
+    autoNavigationEnabled = true, //set autoNavigationEnabled default to true to be downward compatible
+    ...props
+}: IProps<FormValues>) {
     const classes = useStyles();
     const client = useApolloClient();
     const dirtyHandler = React.useContext(DirtyHandlerApiContext);
@@ -126,7 +130,7 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
                                     props.renderButtons(formRenderProps)
                                 ) : (
                                     <ButtonsContainer>
-                                        {stackApi && (
+                                        {stackApi && autoNavigationEnabled && (
                                             <Button
                                                 className={classes.saveButton}
                                                 startIcon={<CancelIcon />}
@@ -187,11 +191,13 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
                         }
                     }
 
-                    if (stackApi) {
+                    if (stackApi && autoNavigationEnabled) {
                         // if this form is inside a Stack goBack after save success
                         // do this after form.reset() to have a clean form, so it won't ask for saving changes
                         // TODO we probably shouldn't have a hard dependency to Stack
                         stackApi.goBack();
+                    } else {
+                        form.reset(values); // reset with new initial values so it is not dirty anymore (needed when autoNavigation is disabled)
                     }
                 });
                 return data;


### PR DESCRIPTION
### New:
- adds a new prop (`autoNavigationEnabled`) to `FinalForm` Component
 
With the autoNavigationEnable prop one can disable the auto navigation, which currently happens, when the final form is inside a `StackApiContext`  (e.g. automatically go back after submission finished).

### Intention

Currently it was only possible with a kind of a hack to disable the auto navigation e.g.:

```
<StackSwitch>
        <StackApiContext.Provider value={undefined!!}>
                <FinalForm<Partial<FormValues>>
                    onSubmit={handleSubmit}
                >
                       {/*...*/}
                </FinalForm>
        </<StackApiContext.Provider>
</StackSwitch>
```

In some cases there is a `save` and a `save and go back` button inside a finalform and with this feature one could much easier handle this.

### Story:
![Screen Recording 2021-04-09 at 13 39 13 mov](https://user-images.githubusercontent.com/6098356/114174642-2ea9d600-9939-11eb-8c60-69df85bdd856.gif)
