### PR TITLE
Use stored state hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file. This projec
     -   Using the new `headerHeight` prop, the top-spacing of the content and the menu, will now be adjusted automatically
 -   add new package @comet/admin-icons
 -   add onAfterSubmit to FinalForm
+-   add useStoredState() hook
 
 ### Incompatible Changes
 

--- a/packages/admin-stories/.storybook/preview.tsx
+++ b/packages/admin-stories/.storybook/preview.tsx
@@ -52,7 +52,7 @@ addDecorator((story) => {
     return <ThemeProvider theme={theme}>{story()}</ThemeProvider>;
 });
 
-const order = ["intro-", "comet-"];
+const order = ["intro-", "admin-", "comet-"];
 
 addParameters({
     layout: "padded",

--- a/packages/admin-stories/src/admin/hooks/stored-state/IncrementStoredState.tsx
+++ b/packages/admin-stories/src/admin/hooks/stored-state/IncrementStoredState.tsx
@@ -1,0 +1,31 @@
+import { useStoredState } from "@comet/admin";
+import { Button, Typography } from "@material-ui/core";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+
+storiesOf("@comet/admin/hooks/useStoredState", module).add("Increment Stored State", () => {
+    const [storedState, setStoredState] = useStoredState<number>("stored_state_stories_key", 0);
+    return (
+        <div>
+            <Typography variant={"h4"}> Stored State: {storedState}</Typography>
+
+            <Button
+                variant={"contained"}
+                color={"primary"}
+                onClick={() => {
+                    setStoredState(storedState + 1);
+                }}
+            >
+                Increment Stored State
+            </Button>
+            <Button
+                color={"primary"}
+                onClick={() => {
+                    setStoredState(0);
+                }}
+            >
+                Reset
+            </Button>
+        </div>
+    );
+});

--- a/packages/admin-stories/src/docs/comet/admin/hooks.stories.mdx
+++ b/packages/admin-stories/src/docs/comet/admin/hooks.stories.mdx
@@ -1,0 +1,19 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+
+# Hooks
+
+> Hooks were introduced in React 16.8. They let you use state and other React features without writing a class.
+>
+> More infos on hooks can be found [React Hooks](https://reactjs.org/docs/hooks-intro.html)
+
+<Meta title="docs/@comet/admin/hooks" />
+
+## useStoredState()
+
+The `useStoredState()` hook has a similar api like the `React.useState()` hook. The main difference is, that `useStoredState()` saves and loads the state from and to local storage, so the state is persistent over tabs, and browser restarts.
+
+<Canvas>
+    <Story id="comet-admin-hooks-usestoredstate--increment-stored-state"/>
+</Canvas>
+
+

--- a/packages/admin-stories/src/docs/comet/admin/hooks.stories.mdx
+++ b/packages/admin-stories/src/docs/comet/admin/hooks.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 
 # Hooks
 
@@ -13,7 +13,5 @@ import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
 The `useStoredState()` hook has a similar api like the `React.useState()` hook. The main difference is, that `useStoredState()` saves and loads the state from and to local storage, so the state is persistent over tabs, and browser restarts.
 
 <Canvas>
-    <Story id="comet-admin-hooks-usestoredstate--increment-stored-state"/>
+    <Story id="comet-admin-hooks-usestoredstate--increment-stored-state" />
 </Canvas>
-
-

--- a/packages/admin/src/hooks/index.ts
+++ b/packages/admin/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from "./useStoredState";

--- a/packages/admin/src/hooks/useStoredState.ts
+++ b/packages/admin/src/hooks/useStoredState.ts
@@ -1,0 +1,48 @@
+import * as React from "react";
+
+// inspired by https://stackoverflow.com/questions/24613955/is-there-a-type-in-typescript-for-anything-except-functions#answer-48045023
+type NoFunctionValue = boolean | string | number | null | undefined | NoFunctionObject | NoFunctionArray;
+
+type NoFunctionObject = object; // @TODO this is not accurate, must be an object without functions as values
+
+type NoFunctionArray = Array<NoFunctionValue>;
+
+// inspired by https://usehooks.com/useLocalStorage/
+function useStoredState<S extends NoFunctionValue = undefined>(
+    key: string | false,
+    initialValue: S | (() => S),
+    storage = window.localStorage,
+): [S, React.Dispatch<React.SetStateAction<S>>] {
+    const [state, setState] = React.useState<S>(() => {
+        if (key === false) {
+            return initialValue instanceof Function ? initialValue() : initialValue;
+        }
+
+        try {
+            const item = storage.getItem(key);
+            return item ? (JSON.parse(item) as S) : initialValue instanceof Function ? initialValue() : initialValue;
+        } catch (error) {
+            // If error also return initialValue
+            console.log(error);
+            return initialValue instanceof Function ? initialValue() : initialValue;
+        }
+    });
+
+    const serializedState = React.useMemo(() => JSON.stringify(state), [state]);
+
+    React.useEffect(() => {
+        if (key === false) {
+            return;
+        }
+
+        try {
+            storage.setItem(key, serializedState);
+        } catch (error) {
+            // A more advanced implementation would handle the error case
+            console.log(error);
+        }
+    }, [serializedState, key, storage]);
+
+    return [state, setState];
+}
+export { useStoredState };

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -28,3 +28,5 @@ export * from "./SelectionRoute";
 export * from "./Tabs";
 
 export * from "./error";
+
+export * from "./hooks";


### PR DESCRIPTION
The useStoredState() hook has a similar api like the React.useState() hook. The main difference is, that useStoredState() saves and loads the state from and to local storage, so the state is persistent over tabs, and browser restarts.

### New

- [@comet/admin] add useStoredState() Hook 


### Story
![Screen Recording 2021-04-14 at 10 43 07 mov](https://user-images.githubusercontent.com/6098356/114681794-c5e2a500-9d0e-11eb-9592-34dfb7a4c621.gif)
