### PR TITLE
Fix peerDependencies referencing own packages for 2.0

### DIFF
--- a/packages/admin-color-picker/package.json
+++ b/packages/admin-color-picker/package.json
@@ -16,7 +16,7 @@
         "@types/tinycolor2": "^1.4.2"
     },
     "peerDependencies": {
-        "@comet/admin": "^1.2.0",
+        "@comet/admin": "^2.0.0-alpha.0",
         "@material-ui/core": "^4.1.3",
         "@material-ui/icons": "^4.2.1",
         "@material-ui/styles": "^4.1.2",

--- a/packages/admin-date-picker/package.json
+++ b/packages/admin-date-picker/package.json
@@ -17,7 +17,7 @@
         "@types/react-dates": "^17.1.5"
     },
     "peerDependencies": {
-        "@comet/admin": "^1.2.0",
+        "@comet/admin": "^2.0.0-alpha.0",
         "@material-ui/core": "^4.1.3",
         "react": "^16.8",
         "react-final-form": "^6.3.0",

--- a/packages/admin-react-select/package.json
+++ b/packages/admin-react-select/package.json
@@ -15,7 +15,7 @@
         "@types/react-select": "^3.1.2"
     },
     "peerDependencies": {
-        "@comet/admin": "^1.2.0",
+        "@comet/admin": "^2.0.0-alpha.0",
         "@material-ui/core": "^4.1.3",
         "@material-ui/icons": "^4.2.1",
         "final-form": "^4.16.1",


### PR DESCRIPTION
fixes
```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: iff-admin@1.0.0
npm ERR! Found: @comet/admin@2.0.0-alpha.0
npm ERR! node_modules/@comet/admin
npm ERR!   @comet/admin@"2.0.0-alpha.0" from iff-admin@1.0.0
npm ERR!   iff-admin
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @comet/admin@"^1.2.0" from @comet/admin-react-select@2.0.0-alpha.0
npm ERR! node_modules/@comet/admin-react-select
npm ERR!   @comet/admin-react-select@"2.0.0-alpha.0" from iff-admin@1.0.0
npm ERR!   iff-admin
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```