### PR TITLE
remove graphql-tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
                 "file-saver": "^2.0.2",
                 "final-form": "^4.16.1",
                 "graphql": "^15.4.0",
-                "graphql-tag": "^2.11.0",
                 "history": "^4.10.1",
                 "husky": "^6.0.0",
                 "jss": "^9.8.7",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
         "file-saver": "^2.0.2",
         "final-form": "^4.16.1",
         "graphql": "^15.4.0",
-        "graphql-tag": "^2.11.0",
         "history": "^4.10.1",
         "husky": "^6.0.0",
         "jss": "^9.8.7",

--- a/packages/admin-stories/src/admin/stack/StackTableFormQueryAtStack.tsx
+++ b/packages/admin-stories/src/admin/stack/StackTableFormQueryAtStack.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@apollo/client";
+import { gql, useQuery } from "@apollo/client";
 import {
     Field,
     FinalForm,
@@ -17,7 +17,6 @@ import {
 import { CircularProgress, Grid, IconButton } from "@material-ui/core";
 import { Edit as EditIcon } from "@material-ui/icons";
 import { storiesOf } from "@storybook/react";
-import gql from "graphql-tag";
 import * as React from "react";
 import StoryRouter from "storybook-react-router";
 

--- a/packages/admin-stories/src/admin/stack/StackTableFormQueryInTable.tsx
+++ b/packages/admin-stories/src/admin/stack/StackTableFormQueryInTable.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@apollo/client";
+import { gql, useQuery } from "@apollo/client";
 import {
     Field,
     FinalForm,
@@ -17,7 +17,6 @@ import {
 import { CircularProgress, Grid, IconButton } from "@material-ui/core";
 import { Edit as EditIcon } from "@material-ui/icons";
 import { storiesOf } from "@storybook/react";
-import gql from "graphql-tag";
 import * as React from "react";
 import StoryRouter from "storybook-react-router";
 

--- a/packages/admin-stories/src/admin/table/TableBesidesForm.tsx
+++ b/packages/admin-stories/src/admin/table/TableBesidesForm.tsx
@@ -1,3 +1,4 @@
+import { gql } from "@apollo/client";
 import {
     DirtyHandler,
     Field,
@@ -12,7 +13,6 @@ import {
     useTableQuery,
 } from "@comet/admin";
 import { storiesOf } from "@storybook/react";
-import gql from "graphql-tag";
 import * as React from "react";
 import { Redirect, Route, Switch } from "react-router";
 import StoryRouter from "storybook-react-router";

--- a/packages/admin-stories/src/admin/table/TableBesidesFormSelectionHooks.tsx
+++ b/packages/admin-stories/src/admin/table/TableBesidesFormSelectionHooks.tsx
@@ -1,3 +1,4 @@
+import { gql } from "@apollo/client";
 import {
     DirtyHandler,
     Field,
@@ -12,7 +13,6 @@ import {
     useTableQuery,
 } from "@comet/admin";
 import { storiesOf } from "@storybook/react";
-import gql from "graphql-tag";
 import * as React from "react";
 import { Redirect, Route, Switch } from "react-router";
 import StoryRouter from "storybook-react-router";

--- a/packages/admin-stories/src/admin/table/TableExportAllPages.tsx
+++ b/packages/admin-stories/src/admin/table/TableExportAllPages.tsx
@@ -1,3 +1,4 @@
+import { gql } from "@apollo/client";
 import {
     createRestStartLimitPagingActions,
     ExcelExportButton,
@@ -8,7 +9,6 @@ import {
     useTableQueryPaging,
 } from "@comet/admin";
 import { storiesOf } from "@storybook/react";
-import gql from "graphql-tag";
 import * as React from "react";
 
 import { apolloStoryDecorator } from "../../apollo-story.decorator";

--- a/packages/admin-stories/src/admin/table/TableExportWithLimit.tsx
+++ b/packages/admin-stories/src/admin/table/TableExportWithLimit.tsx
@@ -1,3 +1,4 @@
+import { gql } from "@apollo/client";
 import {
     createRestStartLimitPagingActions,
     ExcelExportButton,
@@ -9,7 +10,6 @@ import {
     useTableQueryPaging,
 } from "@comet/admin";
 import { storiesOf } from "@storybook/react";
-import gql from "graphql-tag";
 import * as React from "react";
 
 import { apolloStoryDecorator } from "../../apollo-story.decorator";

--- a/packages/admin-stories/src/admin/table/TableExportWithLimitFilter.tsx
+++ b/packages/admin-stories/src/admin/table/TableExportWithLimitFilter.tsx
@@ -1,3 +1,4 @@
+import { gql } from "@apollo/client";
 import {
     createRestStartLimitPagingActions,
     ExcelExportButton,
@@ -14,7 +15,6 @@ import {
     VisibleType,
 } from "@comet/admin";
 import { storiesOf } from "@storybook/react";
-import gql from "graphql-tag";
 import * as React from "react";
 
 import { apolloStoryDecorator } from "../../apollo-story.decorator";

--- a/packages/admin-stories/src/admin/table/TableFilter.tsx
+++ b/packages/admin-stories/src/admin/table/TableFilter.tsx
@@ -1,6 +1,6 @@
+import { gql } from "@apollo/client";
 import { Field, FinalFormInput, Table, TableFilterFinalForm, TableQuery, useTableQuery, useTableQueryFilter } from "@comet/admin";
 import { storiesOf } from "@storybook/react";
-import gql from "graphql-tag";
 import * as qs from "qs";
 import * as React from "react";
 

--- a/packages/admin-stories/src/admin/table/TableFilterPagingSort.tsx
+++ b/packages/admin-stories/src/admin/table/TableFilterPagingSort.tsx
@@ -1,3 +1,4 @@
+import { gql } from "@apollo/client";
 import {
     createRestPagingActions,
     Field,
@@ -12,7 +13,6 @@ import {
     useTableQuerySort,
 } from "@comet/admin";
 import { storiesOf } from "@storybook/react";
-import gql from "graphql-tag";
 import * as qs from "qs";
 import * as React from "react";
 

--- a/packages/admin-stories/src/admin/table/TablePaging.tsx
+++ b/packages/admin-stories/src/admin/table/TablePaging.tsx
@@ -1,6 +1,6 @@
+import { gql } from "@apollo/client";
 import { createRestPagingActions, Table, TableQuery, useTableQuery, useTableQueryPaging } from "@comet/admin";
 import { storiesOf } from "@storybook/react";
-import gql from "graphql-tag";
 import * as React from "react";
 
 import { apolloStoryDecorator } from "../../apollo-story.decorator";

--- a/packages/admin-stories/src/admin/table/TableResetFilter.tsx
+++ b/packages/admin-stories/src/admin/table/TableResetFilter.tsx
@@ -1,8 +1,8 @@
+import { gql } from "@apollo/client";
 import { Field, Table, TableFilterFinalForm, TableQuery, useTableQuery, useTableQueryFilter } from "@comet/admin";
 import { FinalFormReactSelectStaticOptions } from "@comet/admin-react-select";
 import { Grid } from "@material-ui/core";
 import { storiesOf } from "@storybook/react";
-import gql from "graphql-tag";
 import * as qs from "qs";
 import * as React from "react";
 

--- a/packages/admin-stories/src/admin/table/TableSort.tsx
+++ b/packages/admin-stories/src/admin/table/TableSort.tsx
@@ -1,6 +1,6 @@
+import { gql } from "@apollo/client";
 import { SortDirection, Table, TableQuery, useTableQuery, useTableQuerySort } from "@comet/admin";
 import { storiesOf } from "@storybook/react";
-import gql from "graphql-tag";
 import * as React from "react";
 
 import { apolloStoryDecorator } from "../../apollo-story.decorator";

--- a/packages/admin/src/buildRestMutation.tsx
+++ b/packages/admin/src/buildRestMutation.tsx
@@ -1,4 +1,4 @@
-import gql from "graphql-tag";
+import { gql } from "@apollo/client";
 
 export function buildUpdateRestMutation(options: { type: string; path: string; responseFragment: any }) {
     const { type, path, responseFragment } = options;


### PR DESCRIPTION
As per https://www.apollographql.com/docs/react/migrating/apollo-client-3-migration/:
> The @apollo/client package includes graphql-tag as a dependency and re-exports gql. To simplify your dependencies, we recommend importing gql from @apollo/client and removing all graphql-tag dependencies.