### PR TITLE
Explicitly only import types from theme-augmentation

### DIFF
--- a/packages/admin-theme/src/getThemeOptions.ts
+++ b/packages/admin-theme/src/getThemeOptions.ts
@@ -1,8 +1,7 @@
-import "@comet/admin/src/themeAugmentation";
-import "@comet/admin-rte/src/themeAugmentation";
-import "@comet/admin-react-select/src/themeAugmentation";
-import "@comet/admin-color-picker/src/themeAugmentation";
-
+import type {} from "@comet/admin-color-picker/src/themeAugmentation";
+import type {} from "@comet/admin-react-select/src/themeAugmentation";
+import type {} from "@comet/admin-rte/src/themeAugmentation";
+import type {} from "@comet/admin/src/themeAugmentation";
 import { ThemeOptions } from "@material-ui/core/styles";
 
 import cometAdminColorPickerOverrides from "./cometAdminColorPickerOverrides/colorPicker";


### PR DESCRIPTION
This prevents the compiled js from requiring the packages from which the types are needed.