### PR TITLE
Improve internationalizability by using React.ReactNode instead of string

### DIFF
--- a/packages/admin/src/EditDialog.tsx
+++ b/packages/admin/src/EditDialog.tsx
@@ -10,8 +10,8 @@ import { ISelectionApi } from "./SelectionApi";
 import { useSelectionRoute } from "./SelectionRoute";
 
 interface ITitle {
-    edit: string;
-    add: string;
+    edit: React.ReactNode;
+    add: React.ReactNode;
 }
 
 interface IProps {

--- a/packages/admin/src/RouterTabs.tsx
+++ b/packages/admin/src/RouterTabs.tsx
@@ -10,7 +10,7 @@ import { StackApiContext, StackBreadcrumb, StackSwitchApiContext } from "./stack
 
 interface ITabProps extends TabProps {
     path: string;
-    label: string;
+    label: React.ReactNode;
     forceRender?: boolean;
     tabLabel?: React.ReactNode;
     children: React.ReactNode;

--- a/packages/admin/src/Tabs.tsx
+++ b/packages/admin/src/Tabs.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import styled from "styled-components";
 
 interface ITabProps extends TabProps {
-    label: string;
+    label: React.ReactNode;
     tabLabel?: React.ReactNode;
     children: React.ReactNode;
 }

--- a/packages/admin/src/error/errorboundary/ErrorBoundary.tsx
+++ b/packages/admin/src/error/errorboundary/ErrorBoundary.tsx
@@ -24,7 +24,7 @@ export interface ErrorBoundaryThemeProps {
 }
 
 interface ErrorBoundaryProps extends ErrorBoundaryThemeProps, WithStyles<CometAdminErrorBoundaryClassKeys> {
-    userErrorMessage?: string;
+    userErrorMessage?: React.ReactNode;
 }
 
 interface IErrorBoundaryState {

--- a/packages/admin/src/form/Field.tsx
+++ b/packages/admin/src/form/Field.tsx
@@ -10,7 +10,7 @@ const composeValidators = (...validators: Array<(value: any, allValues: object) 
 
 interface IVividFieldProps<FieldValue = any, T extends HTMLElement = HTMLElement> {
     name: string;
-    label?: string;
+    label?: React.ReactNode;
     component?: React.ComponentType<any> | string;
     children?: (props: FieldRenderProps<FieldValue, T>) => React.ReactNode;
     required?: boolean;

--- a/packages/admin/src/form/FieldContainer.tsx
+++ b/packages/admin/src/form/FieldContainer.tsx
@@ -8,7 +8,7 @@ export interface FieldContainerThemeProps {
 }
 
 interface FieldContainerProps {
-    label?: string | React.ReactNode;
+    label?: React.ReactNode;
     required?: boolean;
     disabled?: boolean;
     error?: string;

--- a/packages/admin/src/form/FinalFormRangeInput.tsx
+++ b/packages/admin/src/form/FinalFormRangeInput.tsx
@@ -40,8 +40,8 @@ const styles = (theme: Theme) => {
 interface IFinalFormRangeInputProps extends FieldRenderProps<{ min: number; max: number }, HTMLInputElement> {
     min: number;
     max: number;
-    startAdornment?: string | React.ReactElement;
-    endAdornment?: string | React.ReactElement;
+    startAdornment?: React.ReactNode;
+    endAdornment?: React.ReactNode;
     sliderProps?: Omit<SliderProps, "min" | "max">;
 }
 
@@ -79,8 +79,8 @@ const FinalFormRangeInputComponent: React.FunctionComponent<WithStyles<typeof st
                                 value: internalMinInput,
                                 type: "number",
                             }}
-                            startAdornment={startAdornment ? startAdornment : ""}
-                            endAdornment={endAdornment ? endAdornment : ""}
+                            startAdornment={startAdornment}
+                            endAdornment={endAdornment}
                             onBlur={() => {
                                 const minFieldValue = Math.min(internalMinInput, fieldValue.max);
                                 if (fieldValue.min !== minFieldValue) {

--- a/packages/admin/src/table/Table.tsx
+++ b/packages/admin/src/table/Table.tsx
@@ -94,7 +94,7 @@ export type Visible = boolean | { [key in VisibleType]?: boolean };
 export interface ITableColumn<TRow extends IRow> {
     name: string;
     visible?: Visible;
-    header?: string | React.ReactNode;
+    header?: React.ReactNode;
     headerExcel?: string;
     render?: (row: TRow) => React.ReactNode;
     renderExcel?: (row: TRow) => string | number;

--- a/packages/admin/src/table/TableFilterFinalForm.tsx
+++ b/packages/admin/src/table/TableFilterFinalForm.tsx
@@ -9,7 +9,7 @@ import { renderComponent } from "../finalFormRenderComponent";
 import { IFilterApi } from "./useTableQueryFilter";
 
 type Props<FilterValues = AnyObject> = Omit<FormProps<FilterValues>, "onSubmit" | "initialValues"> & {
-    headline?: string;
+    headline?: React.ReactNode;
     resetButton?: boolean;
     onSubmit?: FormProps<FilterValues>["onSubmit"];
     filterApi: IFilterApi<FilterValues>;


### PR DESCRIPTION
This change allows the direct use of `<FormattedMessage ... >` instead of `intl.formatMessage(...)` on several occasions.