### PR TITLE
Add remote-container setup for running pull-requests

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/typescript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version: 16, 14, 12
+ARG VARIANT="16-buster"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# Install an additional version of node using nvm
+ARG EXTRA_NODE_VERSION=14
+RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# Install more global node packages
+RUN su node -c "npm install -g npm@7 lerna pm2"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,4 +13,4 @@ ARG EXTRA_NODE_VERSION=14
 RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
 
 # Install more global node packages
-RUN su node -c "npm install -g npm@7 lerna pm2"
+RUN su node -c "npm install -g npm@7.13 lerna pm2"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,4 +13,4 @@ ARG EXTRA_NODE_VERSION=14
 RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
 
 # Install more global node packages
-RUN su node -c "npm install -g npm@7.13 lerna pm2"
+RUN su node -c "npm install -g npm@7.13"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/typescript-node
+{
+    "name": "Node.js & TypeScript",
+    "build": {
+        "dockerfile": "Dockerfile",
+        // Update 'VARIANT' to pick a Node version: 12, 14, 16
+        "args": {
+            "VARIANT": "14"
+        }
+    },
+
+    // Set *default* container specific settings.json values on container create.
+    "settings": {
+        "#terminal.integrated.shell.linux#": "/bin/bash",
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.codeActionsOnSave": {
+            "source.fixAll.eslint": true
+        }
+    },
+
+    // Add the IDs of extensions you want installed when the container is created.
+    "extensions": ["dbaeumer.vscode-eslint", "jpoissonnier.vscode-styled-components", "esbenp.prettier-vscode", "alex-young.pm2-explorer"],
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "node",
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "npm set cache .npm && npm i && npm run clean && npm run build",
+    "postStartCommand": "npm start",
+    "shutdownAction": "stopContainer"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 storybook-static/
 comet-admin-lang/
 lang/
+/.npm 


### PR DESCRIPTION
Adds setup to run pull-requests in isolated containers.

Features:

- one command to open and review pull-requests in the editor + dev-setup running
- run multiple pull-requests  (with multiple storybooks) simultaneously
- no other dependencies/configurations on host machine, except docker and vscode
- no need to switch branches when reviewing/developing different pull-requests
- future (still beta): launch container in the cloud and edit it with vscode in the browser with github-codespaces: https://code.visualstudio.com/docs/remote/codespaces

Requirements:
- vscode
- vscode extension: ms-vscode-remote.remote-containers

Open Pull Request:
- launch command `Remote Containers: Clone Github Pull Request in Container Volume` in vscode
- paste url of the pull-request, example: `https://github.com/rabengraph/comet-admin/pull/6` (more: https://code.visualstudio.com/docs/remote/containers#_quick-start-open-a-git-repository-or-github-pr-in-an-isolated-container-volume)

(shows launching the pull-request)
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/2119466/118647733-f328e400-b7e1-11eb-8318-7f6d2356ad54.gif)

(shows spotting the forwarded storybook-port)
![ezgif com-gif-maker](https://user-images.githubusercontent.com/2119466/118647758-fa4ff200-b7e1-11eb-97a7-8a2b11bea701.gif)


Annoying:
 - first time use takes some time to initially build the container image from the DockerFile.

