### PR TITLE
Move border-bottom to paper with variant "outlined"

### DIFF
--- a/packages/admin-theme/src/MuiOverrides/MuiPaper.ts
+++ b/packages/admin-theme/src/MuiOverrides/MuiPaper.ts
@@ -6,10 +6,13 @@ import { paletteOptions } from "../paletteOptions";
 export const getMuiPaperOverrides = (): StyleRules<{}, PaperClassKey> => ({
     root: {},
     rounded: {},
-    outlined: {},
-    elevation0: {
+    outlined: {
+        borderTop: "none",
+        borderRight: "none",
         borderBottom: `1px solid ${paletteOptions.divider}`,
+        borderLeft: "none",
     },
+    elevation0: {},
     elevation1: {},
     elevation2: {},
     elevation3: {},


### PR DESCRIPTION
According to the comet design specifications, every paper, without a shadow/elevation should have a 1px border on the bottom, with the "divider" color, defined in the theme.

Often components are used inside the paper that already include a divider at the end (e.g. lists where every item ends with `<Divider />` or a similar border-bottom). In these cases the border-bottom needs to be removed from the paper, which was not easily possible.

Now `<Paper elevation={0} />` should be used for those cases, where a border/divider already exists at the end and `<Paper vairant="outlined" />` for the cases where the border-bottom needs to be added, as there is no other need in comet for a fully outlined paper component, as was intended by material-ui.