### PR TITLE
Don't set class-key that doesn't exist

### DIFF
--- a/packages/admin-theme/src/MuiOverrides/MuiCheckbox.ts
+++ b/packages/admin-theme/src/MuiOverrides/MuiCheckbox.ts
@@ -3,7 +3,10 @@ import { StyleRules } from "@material-ui/styles/withStyles";
 
 import { bluePalette, greenPalette, neutrals } from "../colors";
 
-export const getMuiCheckboxOverrides = (): StyleRules<{}, CheckboxClassKey> => ({
+// Key "input" is not a stylable class-key on MuiCheckbox
+type CorrectedCheckboxClassKey = Exclude<CheckboxClassKey, "input">;
+
+export const getMuiCheckboxOverrides = (): StyleRules<{}, CorrectedCheckboxClassKey> => ({
     root: {
         "& [class*='MuiSvgIcon-root']": {
             "& .border": {
@@ -37,7 +40,6 @@ export const getMuiCheckboxOverrides = (): StyleRules<{}, CheckboxClassKey> => (
     },
     checked: {},
     disabled: {},
-    input: {},
     indeterminate: {},
     colorPrimary: {
         "&$checked [class*='MuiSvgIcon-root']": {

--- a/packages/admin-theme/src/MuiOverrides/MuiRadio.ts
+++ b/packages/admin-theme/src/MuiOverrides/MuiRadio.ts
@@ -3,7 +3,10 @@ import { StyleRules } from "@material-ui/styles/withStyles";
 
 import { bluePalette, greenPalette, neutrals } from "../colors";
 
-export const getMuiRadioOverrides = (): StyleRules<{}, RadioClassKey> => ({
+// Key "input" is not a stylable class-key on MuiRadio
+type CorrectedRadioClassKey = Exclude<RadioClassKey, "input">;
+
+export const getMuiRadioOverrides = (): StyleRules<{}, CorrectedRadioClassKey> => ({
     root: {
         "& [class*='MuiSvgIcon-root']": {
             "& .border": {
@@ -37,7 +40,6 @@ export const getMuiRadioOverrides = (): StyleRules<{}, RadioClassKey> => ({
     },
     checked: {},
     disabled: {},
-    input: {},
     colorPrimary: {
         "&$checked [class*='MuiSvgIcon-root']": {
             "& .background": {


### PR DESCRIPTION
The "input" key exists on the class-key-types but is not included in the stylable class-keys.