### PR TITLE
Allow full-width for horizontal fields

### DIFF
--- a/packages/admin-theme/src/AdminOverrides/formFieldContainer.ts
+++ b/packages/admin-theme/src/AdminOverrides/formFieldContainer.ts
@@ -15,6 +15,7 @@ export const getFormFieldContainerOverrides = (): StyleRules<{}, CometAdminFormF
         },
     },
     horizontal: {},
+    fullWidth: {},
     required: {},
     disabled: {},
     label: {

--- a/packages/admin/src/form/Field.tsx
+++ b/packages/admin/src/form/Field.tsx
@@ -32,7 +32,7 @@ export class Field<FieldValue = any, T extends HTMLElement = HTMLElement> extend
     }
 
     private renderField({ input, meta, fieldContainerProps, ...rest }: FieldRenderProps<FieldValue, T>) {
-        const { children, component, name, label, required, disabled, variant } = this.props;
+        const { children, component, name, label, required, disabled, variant, fullWidth } = this.props;
 
         function render() {
             if (component) {
@@ -51,6 +51,7 @@ export class Field<FieldValue = any, T extends HTMLElement = HTMLElement> extend
                 disabled={disabled}
                 error={(meta.error || meta.submitError) && meta.touched && (meta.error || meta.submitError)}
                 variant={variant}
+                fullWidth={fullWidth}
             >
                 {render()}
             </FieldContainer>

--- a/packages/admin/src/form/FieldContainer.tsx
+++ b/packages/admin/src/form/FieldContainer.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 
 export interface FieldContainerThemeProps {
     variant?: "vertical" | "horizontal";
+    fullWidth?: boolean;
     requiredSymbol?: React.ReactNode;
 }
 
@@ -18,6 +19,7 @@ export type CometAdminFormFieldContainerClassKeys =
     | "root"
     | "vertical"
     | "horizontal"
+    | "fullWidth"
     | "required"
     | "disabled"
     | "label"
@@ -46,7 +48,12 @@ const styles = (theme: Theme) => {
                 flexShrink: 0,
                 flexGrow: 0,
             },
+
+            "&$fullWidth $inputContainer": {
+                flexGrow: 1,
+            },
         },
+        fullWidth: {},
         required: {},
         disabled: {},
         label: {
@@ -61,6 +68,7 @@ const styles = (theme: Theme) => {
 export const FieldContainerComponent: React.FC<WithStyles<typeof styles, true> & FieldContainerProps & FieldContainerThemeProps> = ({
     classes,
     variant = "vertical",
+    fullWidth,
     label,
     error,
     disabled,
@@ -71,6 +79,7 @@ export const FieldContainerComponent: React.FC<WithStyles<typeof styles, true> &
     const formControlClasses: string[] = [classes.root];
     if (variant === "vertical") formControlClasses.push(classes.vertical);
     if (variant === "horizontal") formControlClasses.push(classes.horizontal);
+    if (fullWidth) formControlClasses.push(classes.fullWidth);
     if (error) formControlClasses.push(classes.hasError);
     if (disabled) formControlClasses.push(classes.disabled);
     if (required) formControlClasses.push(classes.required);


### PR DESCRIPTION
The `inputContainer` would previously not stretch across the full
remaining width of the `FieldContainer` when the `fullWidth`
prop was set.

For vertical fields this already worked, because the `inputContainer`
already stretches across the full width of the `FieldContainer`.