### PR TITLE
Styling fixes and adjustments in InputBase

### DIFF
--- a/packages/admin-theme/src/MuiOverrides/MuiSelect.ts
+++ b/packages/admin-theme/src/MuiOverrides/MuiSelect.ts
@@ -7,9 +7,6 @@ export const getMuiSelectOverrides = (): StyleRules<{}, SelectClassKey> => ({
     root: {},
     select: {
         minWidth: 160,
-        "&:focus": {
-            backgroundColor: "#fff",
-        },
     },
     filled: {},
     outlined: {},

--- a/packages/admin/src/form/InputBase.tsx
+++ b/packages/admin/src/form/InputBase.tsx
@@ -40,6 +40,8 @@ const styles = (theme: Theme) =>
         fullWidth: {},
         colorSecondary: {},
         input: {
+            height: "100%",
+            boxSizing: "border-box",
             paddingLeft: theme.spacing(1),
             paddingRight: theme.spacing(1),
             "&::-ms-clear": {

--- a/packages/admin/src/form/InputBase.tsx
+++ b/packages/admin/src/form/InputBase.tsx
@@ -36,7 +36,10 @@ const styles = (theme: Theme) =>
         },
         error: {},
         marginDense: {},
-        multiline: {},
+        multiline: {
+            paddingTop: 0,
+            paddingBottom: 0,
+        },
         fullWidth: {},
         colorSecondary: {},
         input: {


### PR DESCRIPTION
**Remove unnecessary input-background on focus**
This overlayed the top and bottom border from MuiSelect and FinalFormSelect.

**Prevent input from overlaying the root border**
When the browsers auto-fill sets a background-color on the input, the
border would not be visible anymore.

**Remove padding from multiline input-base**
A padding is alreay set on the input anyway.