### PR TITLE
Replace required key in UndoSnackbar with random uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             ],
             "devDependencies": {
                 "@formatjs/cli": "^2.13.12",
+                "@types/uuid": "^8.3.0",
                 "@typescript-eslint/eslint-plugin": "^4.7.0",
                 "@typescript-eslint/parser": "^4.7.0",
                 "eslint": "^7.13.0",
@@ -6230,6 +6231,12 @@
             "version": "2.0.3",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/uuid": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+            "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
+            "dev": true
         },
         "node_modules/@types/webpack": {
             "version": "4.41.26",
@@ -38030,6 +38037,12 @@
         },
         "@types/unist": {
             "version": "2.0.3",
+            "dev": true
+        },
+        "@types/uuid": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+            "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
             "dev": true
         },
         "@types/webpack": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     },
     "devDependencies": {
         "@formatjs/cli": "^2.13.12",
+        "@types/uuid": "^8.3.0",
         "@typescript-eslint/eslint-plugin": "^4.7.0",
         "@typescript-eslint/parser": "^4.7.0",
         "eslint": "^7.13.0",

--- a/packages/admin-stories/src/admin/snackbar/CustomSnackbar.tsx
+++ b/packages/admin-stories/src/admin/snackbar/CustomSnackbar.tsx
@@ -17,6 +17,8 @@ const CustomSnackbar = () => {
         snackbarApi.showSnackbar(
             <Snackbar
                 anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+                // If no distinct key is set, the Snackbar may update in-place
+                // meaning that the autoHideDuration is not reset (https://material-ui.com/api/snackbar/)
                 // Use uuid or object id in production
                 key={counter++}
                 autoHideDuration={5000}

--- a/packages/admin-stories/src/admin/snackbar/UndoSnackbar.tsx
+++ b/packages/admin-stories/src/admin/snackbar/UndoSnackbar.tsx
@@ -4,8 +4,6 @@ import { ToggleButton, ToggleButtonGroup } from "@material-ui/lab";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
 
-let counter = 0;
-
 const UndoSnackbarExample = () => {
     const [chosenOption, setChosenOption] = React.useState("one");
     const snackbarApi = useSnackbarApi();
@@ -19,7 +17,7 @@ const UndoSnackbarExample = () => {
         setChosenOption(newOption);
 
         snackbarApi.showSnackbar(
-            <UndoSnackbar key={counter++} message={`Changed from ${chosenOption} to ${newOption}`} payload={prevOption} onUndoClick={handleUndo} />,
+            <UndoSnackbar message={`Changed from ${chosenOption} to ${newOption}`} payload={prevOption} onUndoClick={handleUndo} />,
         );
     };
 

--- a/packages/admin-stories/src/docs/components/Snackbar/stories/UndoSnackbar.stories.tsx
+++ b/packages/admin-stories/src/docs/components/Snackbar/stories/UndoSnackbar.stories.tsx
@@ -19,13 +19,7 @@ storiesOf("stories/components/Snackbar/Undo Snackbar", module)
                 const prevOption = chosenOption;
                 setChosenOption(newOption);
                 snackbarApi.showSnackbar(
-                    <UndoSnackbar<string>
-                        // Use uuid or object id in production
-                        key={Math.random()}
-                        message={`Changed from ${chosenOption} to ${newOption}`}
-                        payload={prevOption}
-                        onUndoClick={handleUndo}
-                    />,
+                    <UndoSnackbar<string> message={`Changed from ${chosenOption} to ${newOption}`} payload={prevOption} onUndoClick={handleUndo} />,
                 );
             };
             return (

--- a/packages/admin/src/snackbar/UndoSnackbar.tsx
+++ b/packages/admin/src/snackbar/UndoSnackbar.tsx
@@ -14,6 +14,7 @@ export interface UndoSnackbarProps<Payload extends unknown> extends Omit<Snackba
 
 export const UndoSnackbar = <Payload extends unknown>({ onUndoClick, payload, ...props }: UndoSnackbarProps<Payload>) => {
     const snackbarApi = useSnackbarApi();
+    const uuid = React.useRef(UUID.v4());
 
     const onClick = () => {
         snackbarApi.hideSnackbar();
@@ -22,7 +23,7 @@ export const UndoSnackbar = <Payload extends unknown>({ onUndoClick, payload, ..
 
     return (
         <Snackbar
-            key={UUID.v4()}
+            key={uuid.current}
             anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
             autoHideDuration={5000}
             action={

--- a/packages/admin/src/snackbar/UndoSnackbar.tsx
+++ b/packages/admin/src/snackbar/UndoSnackbar.tsx
@@ -2,11 +2,11 @@ import { Button, Slide, Snackbar, SnackbarProps } from "@material-ui/core";
 import { TransitionProps } from "@material-ui/core/transitions";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
+import * as UUID from "uuid";
 
 import { useSnackbarApi } from "./SnackbarProvider";
 
 export interface UndoSnackbarProps<Payload extends unknown> extends Omit<SnackbarProps, "action"> {
-    key: React.Key;
     message: React.ReactNode;
     onUndoClick: (payload?: Payload) => void;
     payload?: Payload;
@@ -22,6 +22,7 @@ export const UndoSnackbar = <Payload extends unknown>({ onUndoClick, payload, ..
 
     return (
         <Snackbar
+            key={UUID.v4()}
             anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
             autoHideDuration={5000}
             action={


### PR DESCRIPTION
- Make key on `UndoSnackbar` non-required
- Per default add a random uuid as `UndoSnackbar` key

The reason is that the Mui Snackbar is updated in-place if two snackbars have the same key. In this case, the autoHideDuration is not reset. This means if an object.id is used as key and the object is updated multiple times successively, the last Snackbar is not shown for 5 seconds but only a fraction of that.

According to the Mui docs, this can also happen if no key is set. Therefore, a uuid is used as default value.

> When displaying multiple consecutive Snackbars from a parent rendering a single <Snackbar/>, add the key prop to ensure independent treatment of each message. e.g. <Snackbar key={message} />, otherwise, the message may update-in-place and features such as autoHideDuration may be canceled.

https://material-ui.com/api/snackbar/