### PR TITLE
Add ability to disable top/bottom padding in MainContent

### DIFF
--- a/packages/admin-theme/src/AdminOverrides/getAdminOverrides.ts
+++ b/packages/admin-theme/src/AdminOverrides/getAdminOverrides.ts
@@ -8,7 +8,6 @@ import { getFinalFormSearchTextFieldOverrides } from "./finalFormSearchTextField
 import { getFormFieldContainerOverrides } from "./formFieldContainer";
 import { getFormPaperOverrides } from "./formPaper";
 import { getInputBaseOverrides } from "./inputBase";
-import { getMainContentOverrides } from "./maincontent";
 import { getMasterLayoutOverrides } from "./masterLayout";
 import { getMenuOverrides } from "./menu";
 import { getMenuCollapsibleItemOverrides } from "./menuCollapsibleItem";
@@ -29,7 +28,6 @@ export const getAdminOverrides = (palette: Palette): Overrides => ({
     CometAdminMenu: getMenuOverrides(),
     CometAdminMenuItem: getMenuItemOverrides(palette),
     CometAdminMenuCollapsibleItem: getMenuCollapsibleItemOverrides(palette),
-    CometAdminMainContent: getMainContentOverrides(),
     CometAdminMasterLayout: getMasterLayoutOverrides(palette),
     CometAdminFinalFormSaveCancelButtonsLegacy: getFinalFormSaveCancelButtonsLegacyOverrides(),
     CometAdminToolbar: getToolbarOverrides(),

--- a/packages/admin-theme/src/AdminOverrides/maincontent.ts
+++ b/packages/admin-theme/src/AdminOverrides/maincontent.ts
@@ -1,8 +1,0 @@
-import { CometAdminMainContentClassKeys } from "@comet/admin";
-import { StyleRules } from "@material-ui/styles/withStyles";
-
-export const getMainContentOverrides = (): StyleRules<{}, CometAdminMainContentClassKeys> => ({
-    root: {
-        padding: 20,
-    },
-});

--- a/packages/admin/src/mui/MainContent.tsx
+++ b/packages/admin/src/mui/MainContent.tsx
@@ -1,24 +1,52 @@
-import { Theme } from "@material-ui/core/styles";
-import { createStyles, WithStyles, withStyles } from "@material-ui/styles";
+import { makeStyles } from "@material-ui/core";
+import { StyledComponentProps, Theme } from "@material-ui/core/styles";
 import * as React from "react";
 
-export type CometAdminMainContentClassKeys = "root";
+import { mergeClasses } from "../helpers/mergeClasses";
 
-const styles = (theme: Theme) =>
-    createStyles<CometAdminMainContentClassKeys, any>({
+export interface MainContentProps {
+    children?: React.ReactNode;
+    disablePaddingTop?: boolean;
+    disablePaddingBottom?: boolean;
+}
+
+export function MainContent({
+    children,
+    disablePaddingTop,
+    disablePaddingBottom,
+    classes: passedClasses,
+}: MainContentProps & StyledComponentProps<CometAdminMainContentClassKeys>) {
+    const classes = mergeClasses<CometAdminMainContentClassKeys>(useStyles(), passedClasses);
+    const rootClasses: string[] = [classes.root];
+    if (disablePaddingTop) rootClasses.push(classes.disablePaddingTop);
+    if (disablePaddingBottom) rootClasses.push(classes.disablePaddingBottom);
+    return <main className={rootClasses.join(" ")}>{children}</main>;
+}
+
+export type CometAdminMainContentClassKeys = "root" | "disablePaddingTop" | "disablePaddingBottom";
+
+export const useStyles = makeStyles<Theme, {}, CometAdminMainContentClassKeys>(
+    ({ spacing }) => ({
         root: {
             position: "relative",
             zIndex: 5,
-            padding: theme.spacing(4),
+            padding: spacing(4),
         },
-    });
+        disablePaddingTop: {
+            paddingTop: 0,
+        },
+        disablePaddingBottom: {
+            paddingBottom: 0,
+        },
+    }),
+    { name: "CometAdminMainContent" },
+);
 
-const MainContent: React.FC<WithStyles<typeof styles> & CometAdminMainContentClassKeys> = ({ classes, children }) => {
-    return <main className={classes.root}>{children}</main>;
-};
-
-const StyledCometAdminMainContent = withStyles(styles, { name: "CometAdminMainContent", withTheme: true })(MainContent);
-export { StyledCometAdminMainContent as MainContent };
+declare module "@material-ui/core/styles/props" {
+    interface ComponentsPropsList {
+        CometAdminMainContent: MainContentProps;
+    }
+}
 
 declare module "@material-ui/core/styles/overrides" {
     interface ComponentNameToClassKey {


### PR DESCRIPTION
In some instances, content inside `MainContent` needs to span to the
top or bottom edge of the page.