### PR TITLE
Fix fullWidth prop in FieldContainer

### DIFF
--- a/packages/admin/src/form/FieldContainer.tsx
+++ b/packages/admin/src/form/FieldContainer.tsx
@@ -85,7 +85,7 @@ export const FieldContainerComponent: React.FC<WithStyles<typeof styles, true> &
     if (required) formControlClasses.push(classes.required);
 
     return (
-        <FormControl fullWidth classes={{ root: formControlClasses.join(" ") }}>
+        <FormControl fullWidth={fullWidth} classes={{ root: formControlClasses.join(" ") }}>
             <>
                 {label && (
                     <FormLabel classes={{ root: classes.label }}>


### PR DESCRIPTION
I've notice that the `fullWidth` prop is not passed through to the `FormControl` component.