### PR TITLE
Only style pre and code tags in story

### DIFF
--- a/packages/admin-stories/.storybook/preview-head.html
+++ b/packages/admin-stories/.storybook/preview-head.html
@@ -7,12 +7,13 @@
         -webkit-font-smoothing: antialiased;
     }
 
-    pre:not(.prismjs) {
+    #root pre:not(.prismjs) {
         background-color: #efefef;
         font-size: 10px;
         padding: 15px;
     }
-    code {
+
+    #root code {
         font-size: 10px;
     }
 </style>


### PR DESCRIPTION
Previously error messages from storybook would also be styled and would therefore appear as white text on a light-grey background, basically unreadable. 