### PR TITLE
Color picker fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6061,15 +6061,6 @@
                 "csstype": "^3.0.2"
             }
         },
-        "node_modules/@types/react-color": {
-            "version": "2.17.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/react": "*",
-                "@types/reactcss": "*"
-            }
-        },
         "node_modules/@types/react-dates": {
             "version": "17.1.15",
             "dev": true,
@@ -27783,7 +27774,7 @@
             },
             "devDependencies": {
                 "@comet/admin": "^2.0.0-alpha.7",
-                "@types/react-color": "2.17.4",
+                "@types/react-color": "^2.17.5",
                 "@types/tinycolor2": "^1.4.2"
             },
             "peerDependencies": {
@@ -27794,6 +27785,16 @@
                 "react": "^16.8",
                 "react-dom": "^16.8",
                 "react-final-form": "^6.3.1"
+            }
+        },
+        "packages/admin-color-picker/node_modules/@types/react-color": {
+            "version": "2.17.5",
+            "resolved": "https://registry.npmjs.org/@types/react-color/-/react-color-2.17.5.tgz",
+            "integrity": "sha512-uJpKNu6yNGbWedNkAeIXY6Qc/eX/kjcdQ0WXD9b//xD3DKwu7VuVuzPlezbhN2EXYVaILNON1HEsrvXoQZuBUw==",
+            "dev": true,
+            "dependencies": {
+                "@types/react": "*",
+                "@types/reactcss": "*"
             }
         },
         "packages/admin-date-picker": {
@@ -32298,10 +32299,22 @@
             "version": "file:packages/admin-color-picker",
             "requires": {
                 "@comet/admin": "^2.0.0-alpha.7",
-                "@types/react-color": "2.17.4",
+                "@types/react-color": "^2.17.5",
                 "@types/tinycolor2": "^1.4.2",
                 "react-color": "^2.19.3",
                 "tinycolor2": "^1.4.1"
+            },
+            "dependencies": {
+                "@types/react-color": {
+                    "version": "2.17.5",
+                    "resolved": "https://registry.npmjs.org/@types/react-color/-/react-color-2.17.5.tgz",
+                    "integrity": "sha512-uJpKNu6yNGbWedNkAeIXY6Qc/eX/kjcdQ0WXD9b//xD3DKwu7VuVuzPlezbhN2EXYVaILNON1HEsrvXoQZuBUw==",
+                    "dev": true,
+                    "requires": {
+                        "@types/react": "*",
+                        "@types/reactcss": "*"
+                    }
+                }
             }
         },
         "@comet/admin-date-picker": {
@@ -37888,14 +37901,6 @@
                 "csstype": {
                     "version": "3.0.7"
                 }
-            }
-        },
-        "@types/react-color": {
-            "version": "2.17.4",
-            "dev": true,
-            "requires": {
-                "@types/react": "*",
-                "@types/reactcss": "*"
             }
         },
         "@types/react-dates": {

--- a/packages/admin-color-picker/package.json
+++ b/packages/admin-color-picker/package.json
@@ -12,7 +12,7 @@
     },
     "devDependencies": {
         "@comet/admin": "^2.0.0-alpha.7",
-        "@types/react-color": "2.17.4",
+        "@types/react-color": "^2.17.5",
         "@types/tinycolor2": "^1.4.2"
     },
     "peerDependencies": {

--- a/packages/admin-color-picker/src/core/HexInput.tsx
+++ b/packages/admin-color-picker/src/core/HexInput.tsx
@@ -31,13 +31,7 @@ const HexInput: React.FC<IComponentProps & ColorPickerProps> = ({ value, classes
     <div className={classes.inputInner}>
         <div className={classes.inputInnerLeftContent}>
             {!palette || (palette && picker) ? (
-                <EditableInput
-                    style={resetInputStyles}
-                    value={value}
-                    onChange={(colorState) => {
-                        onChange(colorState.hex);
-                    }}
-                />
+                <EditableInput style={resetInputStyles} value={value} onChange={onChange} />
             ) : (
                 <div className={classes.readOnlyInput}>{value.toUpperCase()}</div>
             )}

--- a/packages/admin-color-picker/src/core/HexInput.tsx
+++ b/packages/admin-color-picker/src/core/HexInput.tsx
@@ -21,7 +21,7 @@ const resetInputStyles = {
         margin: "inherit",
         cursor: "inherit",
         width: "100%",
-        "&::-ms-clear": {
+        "&::MsClear": {
             display: "none",
         },
     },


### PR DESCRIPTION
**1. Update react-color types to use onchange correctly**
Previously the first parameter of the onChange from EditableInput should have been an object, according to the types which is why it was used incorrectly. The value was a string, this has been corrected in the new version of the types.

**2. Use ms-clear correctly**
This prevents the following react warning: `Warning: Unsupported style property &::-ms-clear.`