### PR TITLE
StackLink and getTargetUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ All notable changes to this project will be documented in this file. This projec
 -   add `FinalFormSaveCancelButtonsLegacy` as drop in replacement for removed Cancel and Save Button in `FinalForm`.
 -   add PrettyBytes component for formatting file sizes and other byte values
 -   Add `validateWarning` validator to `Field` and `FinalForm`.
+-   add `getTargetUrl()` to `StackSwitchApi`
+-   add `StackLink` component for navigating within a `Stack` via hyperlinks
 
 ### Incompatible Changes
 

--- a/packages/admin-stories/src/docs/components/Stack/Stack.stories.mdx
+++ b/packages/admin-stories/src/docs/components/Stack/Stack.stories.mdx
@@ -15,13 +15,43 @@ A single page will be displayed at a time.
     <Story id="stories-components-stack--basic" />
 </Canvas>
 
-A stack consists of 3 components
+A stack consists of 3 components: `Stack`, `StackSwitch` and `StackPage`:
 
--   `Stack`: root component of the stack
--   `StackSwitch`: Container for pages where one will render at a time. Similar to a react-router Switch. Provides a context with an API allowing to switch between pages in this `StackSwitch`.
--   `StackPage`: The pages a `StackSwitch` will switch. First one is the default page.
+### Stack
+
+Root component of the stack.
+
+#### Props
+
+| Name            | Type            | Default value | Description         |
+| :-------------- | :-------------- | :------------ | :------------------ |
+| topLevelTitle\* | React.ReactNode |               | Title of the stack. |
+
+### StackSwitch
+
+Container for pages where one will render at a time. Similar to a react-router Switch. Provides a context with an API allowing to switch between pages in this `StackSwitch`.
+
+#### Props
+
+| Name        | Type                                         | Default value               | Description                                                  |
+| :---------- | :------------------------------------------- | :-------------------------- | :----------------------------------------------------------- |
+| children\*  | Array<React.ReactElement<IStackPageProps\>\> |                             | The `StackPages` that are switched inside the `StackSwitch`. |
+| initialPage | string                                       | First StackPage in children | The `StackPage` that is shown initially.                     |
+| title       | React.ReactNode                              |                             | Title of the `StackSwitch`.                                  |
+
+### StackPage
+
+The pages a `StackSwitch` will switch. First one is the default page.
 
 Comet Admin Stack uses react-router behind the scene and creates a `Route` for every page.
+
+#### Props
+
+| Name       | Type                                                 | Default value | Description                                                                                                                     |
+| :--------- | :--------------------------------------------------- | :------------ | :------------------------------------------------------------------------------------------------------------------------------ |
+| name\*     | string                                               |               | The name of a `StackPage`. Is used for navigating between pages and as page title in the breadcrumbs if no `title` is provided. |
+| children\* | ((id: string) => React.ReactNode) \| React.ReactNode |               | The content of the page.                                                                                                        |
+| title      | React.ReactNode                                      |               | Title of the page. Is used in the breadcrumbs.                                                                                  |
 
 ## Switch page programmatically
 
@@ -49,18 +79,29 @@ This method will activate (navigate to) the given page.
 
 #### Arguments
 
-1. `pageName` (string): name of the page that will be activated
-2. `payload` (string): additional payload containing eg. an id that will get passed into the StackPage
-3. `subUrl` (string [optional]): subUrl to append, for nested stacks or other nested routes
+| Name       | Type            | Default value | Description                                                                                    |
+| :--------- | :-------------- | :------------ | :--------------------------------------------------------------------------------------------- |
+| pageName\* | string          |               | Name of the page that will be activated.                                                       |
+| payload\*  | string          |               | Additional payload containing eg. an id that will get passed into the StackPage.               |
+| subUrl     | string          |               | SubUrl to append, for nested stacks or other nested routes.                                    |
+| switchApi  | IStackSwitchApi |               | Custom switchApi, has to be passed if the StackLink is used outside of a StackSwitch component |
 
 ### StackLink
 
-Alternatively, it's also possible to use the `StackLink` component for creating a link between pages.
-It takes the arguments of `activatePage()` as props.
+It's also possible to use the `StackLink` component for creating a link between pages:
 
 <Canvas>
     <Story id="stories-components-stack--stacklink" />
 </Canvas>
+
+#### Props
+
+| Name       | Type            | Default value | Description                                                                                    |
+| :--------- | :-------------- | :------------ | :--------------------------------------------------------------------------------------------- |
+| pageName\* | string          |               | Name of the page that will be linked to.                                                       |
+| payload\*  | string          |               | Additional payload containing eg. an id that will get passed into the StackPage.               |
+| subUrl     | string          |               | SubUrl to append, for nested stacks or other nested routes.                                    |
+| switchApi  | IStackSwitchApi |               | Custom switchApi, has to be passed if the StackLink is used outside of a StackSwitch component |
 
 ## payload
 
@@ -72,11 +113,11 @@ The activated StackPage can access the payload by rendering a function child lik
     code={dedent`
         <StackPage name="example" title="Example">
             {(id) => <div>{id}</div>}
-        </Stackpage
+        </Stackpage>
 `}
 />
 
-The playload needs to be a string as it is used in the url.
+The payload needs to be a string as it is used in the url.
 
 ### Example
 

--- a/packages/admin-stories/src/docs/components/Stack/Stack.stories.mdx
+++ b/packages/admin-stories/src/docs/components/Stack/Stack.stories.mdx
@@ -79,12 +79,11 @@ This method will activate (navigate to) the given page.
 
 #### Arguments
 
-| Name       | Type            | Default value | Description                                                                                    |
-| :--------- | :-------------- | :------------ | :--------------------------------------------------------------------------------------------- |
-| pageName\* | string          |               | Name of the page that will be activated.                                                       |
-| payload\*  | string          |               | Additional payload containing eg. an id that will get passed into the StackPage.               |
-| subUrl     | string          |               | SubUrl to append, for nested stacks or other nested routes.                                    |
-| switchApi  | IStackSwitchApi |               | Custom switchApi, has to be passed if the StackLink is used outside of a StackSwitch component |
+| Name       | Type   | Default value | Description                                                                      |
+| :--------- | :----- | :------------ | :------------------------------------------------------------------------------- |
+| pageName\* | string |               | Name of the page that will be activated.                                         |
+| payload\*  | string |               | Additional payload containing eg. an id that will get passed into the StackPage. |
+| subUrl     | string |               | SubUrl to append, for nested stacks or other nested routes.                      |
 
 ### StackLink
 
@@ -102,6 +101,26 @@ It's also possible to use the `StackLink` component for creating a link between 
 | payload\*  | string          |               | Additional payload containing eg. an id that will get passed into the StackPage.               |
 | subUrl     | string          |               | SubUrl to append, for nested stacks or other nested routes.                                    |
 | switchApi  | IStackSwitchApi |               | Custom switchApi, has to be passed if the StackLink is used outside of a StackSwitch component |
+
+### getTargetUrl
+
+The `getTargetUrl()` method returns the url of a page in the stack:
+
+<Source
+    language="tsx"
+    code={dedent`
+        const switchApi = useStackSwitchApi();
+        const url = switchApi.getTargetUrl("page2", "test payload");
+  `}
+/>
+
+#### Arguments
+
+| Name       | Type   | Default value | Description                                                                      |
+| :--------- | :----- | :------------ | :------------------------------------------------------------------------------- |
+| pageName\* | string |               | Name of the page that will be activated.                                         |
+| payload\*  | string |               | Additional payload containing eg. an id that will get passed into the StackPage. |
+| subUrl     | string |               | SubUrl to append, for nested stacks or other nested routes.                      |
 
 ## payload
 

--- a/packages/admin-stories/src/docs/components/Stack/Stack.stories.mdx
+++ b/packages/admin-stories/src/docs/components/Stack/Stack.stories.mdx
@@ -77,6 +77,9 @@ To switch between pages use the API provided by `StackSwitch`:
 
 This method will activate (navigate to) the given page.
 
+In case you need the url of a page, it can be obtained by calling `switchApi.getTargetUrl(pageName: string, payload: string, subUrl?: string)`.
+This method should only be used if you cannot achieve your goal with a `StackLink` or `activatePage()`.
+
 #### Arguments
 
 | Name       | Type   | Default value | Description                                                                      |
@@ -87,7 +90,7 @@ This method will activate (navigate to) the given page.
 
 ### StackLink
 
-It's also possible to use the `StackLink` component for creating a link between pages:
+It's also possible to use the `StackLink` component for creating a link to a page:
 
 <Canvas>
     <Story id="stories-components-stack--stacklink" />
@@ -101,26 +104,6 @@ It's also possible to use the `StackLink` component for creating a link between 
 | payload\*  | string          |               | Additional payload containing eg. an id that will get passed into the StackPage.               |
 | subUrl     | string          |               | SubUrl to append, for nested stacks or other nested routes.                                    |
 | switchApi  | IStackSwitchApi |               | Custom switchApi, has to be passed if the StackLink is used outside of a StackSwitch component |
-
-### getTargetUrl
-
-The `getTargetUrl()` method returns the url of a page in the stack:
-
-<Source
-    language="tsx"
-    code={dedent`
-        const switchApi = useStackSwitchApi();
-        const url = switchApi.getTargetUrl("page2", "test payload");
-  `}
-/>
-
-#### Arguments
-
-| Name       | Type   | Default value | Description                                                                      |
-| :--------- | :----- | :------------ | :------------------------------------------------------------------------------- |
-| pageName\* | string |               | Name of the page that will be activated.                                         |
-| payload\*  | string |               | Additional payload containing eg. an id that will get passed into the StackPage. |
-| subUrl     | string |               | SubUrl to append, for nested stacks or other nested routes.                      |
 
 ## payload
 

--- a/packages/admin-stories/src/docs/components/Stack/Stack.stories.mdx
+++ b/packages/admin-stories/src/docs/components/Stack/Stack.stories.mdx
@@ -55,7 +55,12 @@ This method will activate (navigate to) the given page.
 
 ### StackLink
 
-A StackLink component is planned that will work similarly to react-router Link.
+Alternatively, it's also possible to use the `StackLink` component for creating a link between pages.
+It takes the arguments of `activatePage()` as props.
+
+<Canvas>
+    <Story id="stories-components-stack--stacklink" />
+</Canvas>
 
 ## payload
 

--- a/packages/admin-stories/src/docs/components/Stack/Stack.stories.mdx
+++ b/packages/admin-stories/src/docs/components/Stack/Stack.stories.mdx
@@ -23,9 +23,9 @@ Root component of the stack.
 
 #### Props
 
-| Name            | Type            | Default value | Description         |
-| :-------------- | :-------------- | :------------ | :------------------ |
-| topLevelTitle\* | React.ReactNode |               | Title of the stack. |
+| Name            | Type            | Description         |
+| :-------------- | :-------------- | :------------------ |
+| topLevelTitle\* | React.ReactNode | Title of the stack. |
 
 ### StackSwitch
 
@@ -47,11 +47,11 @@ Comet Admin Stack uses react-router behind the scene and creates a `Route` for e
 
 #### Props
 
-| Name       | Type                                                 | Default value | Description                                                                                                                     |
-| :--------- | :--------------------------------------------------- | :------------ | :------------------------------------------------------------------------------------------------------------------------------ |
-| name\*     | string                                               |               | The name of a `StackPage`. Is used for navigating between pages and as page title in the breadcrumbs if no `title` is provided. |
-| children\* | ((id: string) => React.ReactNode) \| React.ReactNode |               | The content of the page.                                                                                                        |
-| title      | React.ReactNode                                      |               | Title of the page. Is used in the breadcrumbs.                                                                                  |
+| Name       | Type                                                 | Description                                                                                                                     |
+| :--------- | :--------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------ |
+| name\*     | string                                               | The name of a `StackPage`. Is used for navigating between pages and as page title in the breadcrumbs if no `title` is provided. |
+| children\* | ((id: string) => React.ReactNode) \| React.ReactNode | The content of the page.                                                                                                        |
+| title      | React.ReactNode                                      | Title of the page. Is used in the breadcrumbs.                                                                                  |
 
 ## Switch page programmatically
 
@@ -82,11 +82,11 @@ This method should only be used if you cannot achieve your goal with a `StackLin
 
 #### Arguments
 
-| Name       | Type   | Default value | Description                                                                      |
-| :--------- | :----- | :------------ | :------------------------------------------------------------------------------- |
-| pageName\* | string |               | Name of the page that will be activated.                                         |
-| payload\*  | string |               | Additional payload containing eg. an id that will get passed into the StackPage. |
-| subUrl     | string |               | SubUrl to append, for nested stacks or other nested routes.                      |
+| Name       | Type   | Description                                                                      |
+| :--------- | :----- | :------------------------------------------------------------------------------- |
+| pageName\* | string | Name of the page that will be activated.                                         |
+| payload\*  | string | Additional payload containing eg. an id that will get passed into the StackPage. |
+| subUrl     | string | SubUrl to append, for nested stacks or other nested routes.                      |
 
 ### StackLink
 
@@ -98,12 +98,12 @@ It's also possible to use the `StackLink` component for creating a link to a pag
 
 #### Props
 
-| Name       | Type            | Default value | Description                                                                                    |
-| :--------- | :-------------- | :------------ | :--------------------------------------------------------------------------------------------- |
-| pageName\* | string          |               | Name of the page that will be linked to.                                                       |
-| payload\*  | string          |               | Additional payload containing eg. an id that will get passed into the StackPage.               |
-| subUrl     | string          |               | SubUrl to append, for nested stacks or other nested routes.                                    |
-| switchApi  | IStackSwitchApi |               | Custom switchApi, has to be passed if the StackLink is used outside of a StackSwitch component |
+| Name       | Type            | Description                                                                                    |
+| :--------- | :-------------- | :--------------------------------------------------------------------------------------------- |
+| pageName\* | string          | Name of the page that will be linked to.                                                       |
+| payload\*  | string          | Additional payload containing eg. an id that will get passed into the StackPage.               |
+| subUrl     | string          | SubUrl to append, for nested stacks or other nested routes.                                    |
+| switchApi  | IStackSwitchApi | Custom switchApi, has to be passed if the StackLink is used outside of a StackSwitch component |
 
 ## payload
 

--- a/packages/admin-stories/src/docs/components/Stack/Stack.stories.tsx
+++ b/packages/admin-stories/src/docs/components/Stack/Stack.stories.tsx
@@ -11,6 +11,7 @@ import {
     useStackSwitch,
     useStackSwitchApi,
 } from "@comet/admin";
+import { StackLink } from "@comet/admin/lib/stack/StackLink";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
 
@@ -260,13 +261,20 @@ storiesOf("stories/components/Stack", module)
         const [StackSwitch, switchApi] = useStackSwitch();
         return (
             <div>
-                <button
-                    onClick={() => {
-                        switchApi.activatePage("page2", "foo");
-                    }}
-                >
-                    page2
-                </button>
+                <p>
+                    <button
+                        onClick={() => {
+                            switchApi.activatePage("page2", "foo");
+                        }}
+                    >
+                        page2
+                    </button>
+                </p>
+                <p>
+                    <StackLink pageName="page2" payload="foo" switchApi={switchApi}>
+                        link to page2
+                    </StackLink>
+                </p>
                 <Stack topLevelTitle="Stack">
                     <StackBreadcrumbs />
                     <StackSwitch>
@@ -279,5 +287,25 @@ storiesOf("stories/components/Stack", module)
                     </StackSwitch>
                 </Stack>
             </div>
+        );
+    })
+    .add("StackLink", () => {
+        return (
+            <Stack topLevelTitle="Example Stack with StackLinks">
+                <StackSwitch>
+                    <StackPage name="page1">
+                        <h3>Page 1</h3>
+                        <StackLink pageName="page2" payload="test">
+                            link to page2
+                        </StackLink>
+                    </StackPage>
+                    <StackPage name="page2">
+                        <h3>Page 2</h3>
+                        <StackLink pageName="page1" payload="test">
+                            link to page1
+                        </StackLink>
+                    </StackPage>
+                </StackSwitch>
+            </Stack>
         );
     });

--- a/packages/admin/src/stack/StackLink.tsx
+++ b/packages/admin/src/stack/StackLink.tsx
@@ -1,0 +1,22 @@
+import { Link } from "@material-ui/core";
+import React, { PropsWithChildren } from "react";
+import { Link as RouterLink } from "react-router-dom";
+
+import { useStackSwitchApi } from "./Switch";
+
+interface StackLinkProps {
+    pageName: string;
+    payload: string;
+    subUrl?: string;
+}
+
+export const StackLink = ({ pageName, payload, subUrl, children }: PropsWithChildren<StackLinkProps>): React.ReactElement => {
+    const stackApi = useStackSwitchApi();
+    const url = React.useMemo(() => stackApi.getTargetUrl(pageName, payload, subUrl), [pageName, payload, stackApi, subUrl]);
+
+    return (
+        <Link to={url} component={RouterLink}>
+            {children}
+        </Link>
+    );
+};

--- a/packages/admin/src/stack/StackLink.tsx
+++ b/packages/admin/src/stack/StackLink.tsx
@@ -2,20 +2,28 @@ import { Link } from "@material-ui/core";
 import React, { PropsWithChildren } from "react";
 import { Link as RouterLink } from "react-router-dom";
 
-import { useStackSwitchApi } from "./Switch";
+import { IStackSwitchApi, useStackSwitchApi } from "./Switch";
 
 interface StackLinkProps {
     pageName: string;
     payload: string;
     subUrl?: string;
+    switchApi?: IStackSwitchApi;
 }
 
-export const StackLink = ({ pageName, payload, subUrl, children }: PropsWithChildren<StackLinkProps>): React.ReactElement => {
-    const stackApi = useStackSwitchApi();
-    const url = React.useMemo(() => stackApi.getTargetUrl(pageName, payload, subUrl), [pageName, payload, stackApi, subUrl]);
+export const StackLink = ({
+    pageName,
+    payload,
+    subUrl,
+    switchApi: externalSwitchApi,
+    children,
+}: PropsWithChildren<StackLinkProps>): React.ReactElement => {
+    const internalSwitchApi = useStackSwitchApi();
+    // external switchApi allows the creation of StackLinks outside of the stack with the useStackSwitch() hook
+    const _switchApi = externalSwitchApi !== undefined ? externalSwitchApi : internalSwitchApi;
 
     return (
-        <Link to={url} component={RouterLink}>
+        <Link to={() => _switchApi.getTargetUrl(pageName, payload, subUrl)} component={RouterLink}>
             {children}
         </Link>
     );

--- a/packages/admin/src/stack/Switch.tsx
+++ b/packages/admin/src/stack/Switch.tsx
@@ -106,13 +106,13 @@ const StackSwitchInner: React.RefForwardingComponent<IStackSwitchApi, IProps & I
 
     const activatePage = React.useCallback(
         (pageName: string, payload: string, subUrl?: string) => {
+            const targetUrl = getTargetUrl(pageName, payload, subUrl);
+            history.push(targetUrl);
+
             if (isInitialPage(pageName)) {
                 if (payload) throw new Error("activating the initialPage must not have a payload");
                 if (subUrl) throw new Error("activating the initialPage must not have a subUrl");
             }
-
-            const targetUrl = getTargetUrl(pageName, payload, subUrl);
-            history.push(targetUrl);
         },
         [getTargetUrl, history, isInitialPage],
     );

--- a/packages/admin/src/stack/Switch.tsx
+++ b/packages/admin/src/stack/Switch.tsx
@@ -54,7 +54,12 @@ export function useStackSwitch(): [React.ComponentType<IProps>, IStackSwitchApi]
             apiRef.current?.activatePage(pageName, payload, subUrl);
         },
         getTargetUrl: (pageName: string, payload: string, subUrl?: string) => {
-            return apiRef.current?.getTargetUrl(pageName, payload, subUrl) || "";
+            if (apiRef.current) {
+                return apiRef.current.getTargetUrl(pageName, payload, subUrl);
+            } else {
+                console.error("apiRef is not attached to a StackSwitch component");
+                return "";
+            }
         },
         updatePageBreadcrumbTitle: (title?: React.ReactNode) => {
             apiRef.current?.updatePageBreadcrumbTitle(title);

--- a/packages/admin/src/stack/Switch.tsx
+++ b/packages/admin/src/stack/Switch.tsx
@@ -8,6 +8,7 @@ const UUID = require("uuid");
 
 interface IProps {
     initialPage?: string;
+    title?: React.ReactNode;
     children: Array<React.ReactElement<IStackPageProps>>;
 }
 

--- a/packages/admin/src/stack/Switch.tsx
+++ b/packages/admin/src/stack/Switch.tsx
@@ -8,7 +8,6 @@ const UUID = require("uuid");
 
 interface IProps {
     initialPage?: string;
-    title?: React.ReactNode;
     children: Array<React.ReactElement<IStackPageProps>>;
 }
 


### PR DESCRIPTION
Draft for `StackLink` and `getTargetUrl`

- `StackLink` provides a react-router link wrapped in a Mui Link for navigating in a stack
- `stackApi.getTargetUrl` returns the url of a stack page that can be navigated to
- `StackLink` and `getTargetUrl` have the same parameters as `stackApi.activatePage`

What do you think about that?

Todo:
- [x] Changelog
- [x] Docs