### PR TITLE
Use "en" as default locale for stories

### DIFF
--- a/packages/admin-stories/.storybook/preview.tsx
+++ b/packages/admin-stories/.storybook/preview.tsx
@@ -46,8 +46,9 @@ addDecorator((story, context) => {
             "cometAdmin.core.table.tableQuery.error": "Fehler :( {error}",
         },
     };
+    const selectedLocale = select("Locale", ["en", "de"], "en");
     return (
-        <IntlProvider locale={select("Locale", ["de", "en"], "de")} messages={messages[select("Locale", ["de", "en"], "de")] ?? {}}>
+        <IntlProvider locale={selectedLocale} messages={messages[selectedLocale] ?? {}}>
             {storyWithKnobs}
         </IntlProvider>
     );


### PR DESCRIPTION
Since all code and communication on github is in english, it makes sense to use english by default. 
Also this prevents annoying error messages in the console about missing translations.