### PR TITLE
Final form context

### DIFF
--- a/packages/admin-stories/src/admin/form/ScrollToErrorField.tsx
+++ b/packages/admin-stories/src/admin/form/ScrollToErrorField.tsx
@@ -1,0 +1,60 @@
+import { Field, FinalForm, FinalFormInput } from "@comet/admin";
+import { Button, Typography } from "@material-ui/core";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+
+import { apolloStoryDecorator } from "../../apollo-story.decorator";
+
+interface FormValues {
+    foo: string;
+    bar: string;
+}
+
+function validate({ foo, bar }: FormValues) {
+    const errors: Partial<Record<keyof FormValues, string>> = {};
+    if (foo !== "foo") {
+        errors.foo = `${foo} is not foo`;
+    }
+    if (bar !== "bar") {
+        errors.bar = `${bar} is not bar`;
+    }
+    return errors;
+}
+
+function Story() {
+    const initialValues = {
+        foo: "foo",
+        bar: "",
+    };
+
+    const [open, setOpen] = React.useState(false);
+    return (
+        <>
+            <Button variant="contained" color="primary" onClick={() => setOpen((s) => !s)}>
+                Click to Render Form
+            </Button>
+            <Typography>The page then scrolls to the 2nd field which has an error.</Typography>
+            {open && (
+                <>
+                    <FinalForm<FormValues>
+                        mode="edit"
+                        onSubmit={() => {
+                            // noop
+                        }}
+                        initialValues={initialValues}
+                        validate={validate}
+                        formContext={{ shouldScrollToField: ({ fieldMeta: { touched } }) => !touched, shouldShowFieldError: () => true }}
+                    >
+                        <Field label="Foo" name="foo" component={FinalFormInput} fullWidth />
+                        <div style={{ height: "2000px", borderLeft: "1px solid black" }}></div>
+                        <Field label="Bar" name="bar" component={FinalFormInput} fullWidth />
+                    </FinalForm>
+                </>
+            )}
+        </>
+    );
+}
+
+storiesOf("@comet/admin/form", module)
+    .addDecorator(apolloStoryDecorator())
+    .add("Scroll To Error Field", () => <Story />);

--- a/packages/admin-stories/src/admin/form/ShowErrorStrategies.tsx
+++ b/packages/admin-stories/src/admin/form/ShowErrorStrategies.tsx
@@ -1,0 +1,86 @@
+import { Field, FinalForm, FinalFormContext, FinalFormInput } from "@comet/admin";
+import { Button, Typography } from "@material-ui/core";
+import { select } from "@storybook/addon-knobs";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+
+import { apolloStoryDecorator } from "../../apollo-story.decorator";
+
+interface FormValues {
+    foo: string;
+    bar: string;
+}
+
+function validate({ foo, bar }: FormValues) {
+    const errors: Partial<Record<keyof FormValues, string>> = {};
+    if (foo !== "foo") {
+        errors.foo = `${foo} is not foo`;
+    }
+    if (bar !== "bar") {
+        errors.bar = `${bar} is not bar`;
+    }
+    return errors;
+}
+
+type ShowStrategy = "always" | "while-typing" | "on-blur" | "when-submitted";
+const strategies: Record<ShowStrategy, FinalFormContext["shouldShowFieldError"]> = {
+    always: () => true,
+    "on-blur": ({ fieldMeta: { touched } }) => !!touched,
+    "while-typing": ({ fieldMeta: { touched, active } }) => !!(touched || active),
+    "when-submitted": ({ fieldMeta: { submitFailed } }) => !!submitFailed,
+};
+
+function Story() {
+    const initialValues = {
+        foo: "foo",
+        bar: "",
+    };
+
+    const selectedStrategytName = select<ShowStrategy>(
+        "Show Error Strategy",
+        ["always", "on-blur", "while-typing", "when-submitted"],
+        "when-submitted",
+    );
+    const shouldShowFieldError = strategies[selectedStrategytName];
+    return (
+        <FinalForm<FormValues>
+            mode="edit"
+            onSubmit={() => {
+                // noop
+            }}
+            initialValues={initialValues}
+            validate={validate}
+            formContext={{ shouldShowFieldError }}
+        >
+            {({ form }) => (
+                <>
+                    <Typography variant="body1">
+                        Demonstrates different implementations of &quot;shouldShowFieldError&quot;. Use Knob to switch strategies.
+                    </Typography>
+
+                    <Typography variant="h3">Show-Error-Strategy: &quot;{selectedStrategytName}&quot;</Typography>
+                    <Field label="Foo" name="foo" component={FinalFormInput} fullWidth />
+                    <Field label="Bar" name="bar" component={FinalFormInput} fullWidth />
+                    <Button variant="contained" color="primary" type="submit">
+                        Submit
+                    </Button>
+                    <Button
+                        variant="contained"
+                        color="secondary"
+                        onClick={() => {
+                            form.reset();
+                            form.resetFieldState("foo");
+                            form.resetFieldState("bar");
+                        }}
+                    >
+                        Reset form and field state
+                    </Button>
+                </>
+            )}
+        </FinalForm>
+    );
+}
+
+storiesOf("@comet/admin/form", module)
+    .addDecorator(apolloStoryDecorator())
+    .add("Show Error Strategies", () => <Story />);

--- a/packages/admin/src/FinalForm.tsx
+++ b/packages/admin/src/FinalForm.tsx
@@ -48,7 +48,7 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
     return (
         <Form
             {...props}
-            mutators={{ ...props.mutators, setFieldData: (setFieldData as unknown) as Mutator<FormValues, object> }}
+            mutators={{ ...props.mutators, setFieldData: setFieldData as unknown as Mutator<FormValues, object> }}
             onSubmit={handleSubmit}
             render={RenderForm}
         />

--- a/packages/admin/src/FinalForm.tsx
+++ b/packages/admin/src/FinalForm.tsx
@@ -60,6 +60,7 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
 
         const submit = React.useCallback(
             (event: any) => {
+                event.preventDefault(); //  Prevents from reloading the page with GET-params on submit
                 if (!formRenderProps.dirty) return;
                 return new Promise<SubmissionErrors | void>((resolve) => {
                     Promise.resolve(formRenderProps.handleSubmit(event)).then(

--- a/packages/admin/src/FinalForm.tsx
+++ b/packages/admin/src/FinalForm.tsx
@@ -8,6 +8,7 @@ import { AnyObject, Form, FormProps, FormRenderProps } from "react-final-form";
 import { DirtyHandlerApiContext } from "./DirtyHandlerApiContext";
 import { EditDialogApiContext } from "./EditDialogApiContext";
 import { renderComponent } from "./finalFormRenderComponent";
+import { FinalFormContext, FinalFormContextProvider } from "./form/FinalFormContextProvider";
 import { SubmitError, SubmitResult } from "./form/SubmitResult";
 import { StackApiContext } from "./stack/Api";
 import { TableQueryContext } from "./table/TableQueryContext";
@@ -25,6 +26,7 @@ interface IProps<FormValues = AnyObject> extends FormProps<FormValues> {
      */
     onAfterSubmit?: (values: FormValues, form: FormApi<FormValues>) => void;
     validateWarning?: (values: FormValues) => ValidationErrors | Promise<ValidationErrors> | undefined;
+    formContext?: Partial<FinalFormContext>;
 }
 
 export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
@@ -46,13 +48,13 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
     return (
         <Form
             {...props}
-            mutators={{ ...props.mutators, setFieldData: setFieldData as unknown as Mutator<FormValues, object> }}
+            mutators={{ ...props.mutators, setFieldData: (setFieldData as unknown) as Mutator<FormValues, object> }}
             onSubmit={handleSubmit}
             render={RenderForm}
         />
     );
 
-    function RenderForm(formRenderProps: FormRenderProps<FormValues>) {
+    function RenderForm({ formContext = {}, ...formRenderProps }: FormRenderProps<FormValues> & { formContext: Partial<FinalFormContext> }) {
         const { mutators } = formRenderProps.form;
         const setFieldData = mutators.setFieldData as ((...args: any[]) => any) | undefined;
 
@@ -152,22 +154,24 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
         }, [formRenderProps.values, setFieldData, registeredFields]);
 
         return (
-            <form onSubmit={submit}>
-                <div>
-                    {renderComponent<FormValues>(
-                        {
-                            children: props.children,
-                            component: props.component,
-                            render: props.render,
-                        },
-                        formRenderProps,
+            <FinalFormContextProvider {...formContext}>
+                <form onSubmit={submit}>
+                    <div>
+                        {renderComponent<FormValues>(
+                            {
+                                children: props.children,
+                                component: props.component,
+                                render: props.render,
+                            },
+                            formRenderProps,
+                        )}
+                    </div>
+                    {(formRenderProps.submitError || formRenderProps.error) && (
+                        <div className="error">{formRenderProps.submitError || formRenderProps.error}</div>
                     )}
-                </div>
-                {(formRenderProps.submitError || formRenderProps.error) && (
-                    <div className="error">{formRenderProps.submitError || formRenderProps.error}</div>
-                )}
-                {!editDialog && <>{formRenderProps.submitting && <CircularProgress />}</>}
-            </form>
+                    {!editDialog && <>{formRenderProps.submitting && <CircularProgress />}</>}
+                </form>
+            </FinalFormContextProvider>
         );
     }
 

--- a/packages/admin/src/form/Field.tsx
+++ b/packages/admin/src/form/Field.tsx
@@ -7,8 +7,10 @@ import { useFinalFormContext } from "./FinalFormContextProvider";
 
 const requiredValidator = (value: any) => (value ? undefined : "Pflichtfeld");
 
-const composeValidators = (...validators: Array<(value: any, allValues: object) => any>) => (value: any, allValues: object) =>
-    validators.reduce((error, validator) => error || validator(value, allValues), undefined);
+const composeValidators =
+    (...validators: Array<(value: any, allValues: object) => any>) =>
+    (value: any, allValues: object) =>
+        validators.reduce((error, validator) => error || validator(value, allValues), undefined);
 
 interface Props<FieldValue = any, T extends HTMLElement = HTMLElement> {
     name: string;

--- a/packages/admin/src/form/FieldContainer.tsx
+++ b/packages/admin/src/form/FieldContainer.tsx
@@ -14,6 +14,7 @@ interface FieldContainerProps {
     disabled?: boolean;
     error?: string;
     warning?: string;
+    scrollTo?: boolean;
 }
 
 export type CometAdminFormFieldContainerClassKeys =
@@ -101,6 +102,7 @@ export const FieldContainerComponent: React.FC<WithStyles<typeof styles, true> &
     requiredSymbol = "*",
     children,
     warning,
+    scrollTo = false,
 }) => {
     const hasError = error !== undefined && error.length > 0;
     const hasWarning = warning !== undefined && warning.length > 0;
@@ -114,8 +116,16 @@ export const FieldContainerComponent: React.FC<WithStyles<typeof styles, true> &
     if (disabled) formControlClasses.push(classes.disabled);
     if (required) formControlClasses.push(classes.required);
 
+    const ref = React.useRef<HTMLDivElement>(null);
+
+    React.useEffect(() => {
+        if (scrollTo) {
+            ref.current?.scrollIntoView({ behavior: "smooth" });
+        }
+    }, [scrollTo]);
+
     return (
-        <FormControl fullWidth={fullWidth} classes={{ root: formControlClasses.join(" ") }}>
+        <FormControl fullWidth={fullWidth} classes={{ root: formControlClasses.join(" ") }} ref={ref}>
             <>
                 {label && (
                     <FormLabel classes={{ root: classes.label }}>

--- a/packages/admin/src/form/FieldContainer.tsx
+++ b/packages/admin/src/form/FieldContainer.tsx
@@ -104,8 +104,8 @@ export const FieldContainerComponent: React.FC<WithStyles<typeof styles, true> &
     warning,
     scrollTo = false,
 }) => {
-    const hasError = error !== undefined && error.length > 0;
-    const hasWarning = warning !== undefined && warning.length > 0;
+    const hasError = !!error;
+    const hasWarning = !!warning;
 
     const formControlClasses: string[] = [classes.root];
     if (variant === "vertical") formControlClasses.push(classes.vertical);

--- a/packages/admin/src/form/FinalFormContextProvider.tsx
+++ b/packages/admin/src/form/FinalFormContextProvider.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { FieldMetaState } from "react-final-form";
+
+export interface FinalFormContext {
+    shouldScrollToField: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
+    shouldShowFieldError: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
+    shouldShowFieldWarning: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
+}
+
+const defaultFinalFormContext: FinalFormContext = {
+    shouldScrollToField: () => false,
+    shouldShowFieldError: ({ fieldMeta }) => !!fieldMeta?.touched,
+    shouldShowFieldWarning: ({ fieldMeta }) => !!fieldMeta?.touched,
+};
+
+const FinalFormContext = React.createContext<FinalFormContext>(defaultFinalFormContext);
+
+export interface FinalFormContextProviderProps extends Partial<FinalFormContext> {
+    children: React.ReactNode;
+}
+
+export function FinalFormContextProvider({ children, ...rest }: FinalFormContextProviderProps): React.ReactElement {
+    return <FinalFormContext.Provider value={{ ...defaultFinalFormContext, ...rest }}>{children}</FinalFormContext.Provider>;
+}
+
+export function useFinalFormContext(): FinalFormContext {
+    return React.useContext(FinalFormContext);
+}

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -153,3 +153,4 @@ export {
     CometAdminCometAdminFinalFormSaveCancelButtonsLegacyThemeProps,
 } from "./FinalFormSaveCancelButtonsLegacy.styles";
 export { PrettyBytes } from "./helpers/PrettyBytes";
+export { FinalFormContext, FinalFormContextProvider, FinalFormContextProviderProps, useFinalFormContext } from "./form/FinalFormContextProvider";


### PR DESCRIPTION
## new:

Introduces a FinalFormContextProvider.

The context keeps these values:

```tsx
interface FinalFormContext {
    shouldShowFieldError: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
    shouldShowFieldWarning: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
    shouldScrollToField: ({ fieldMeta }: { fieldMeta: FieldMetaState<any> }) => boolean;
}
```

The Provider is integrated in `FinalForm.tsx`.

The values can be set via FinalFormProps:

```tsx
<FinalForm formContext={{shouldShowFieldError: () => true}}>
...
</FinalForm>

```

### shouldShowFieldError
Predicate to decide when error-messages on fields of the form should be shown.

### shouldShowFieldWarning
Predicate to decide when warning-messages on fields of the form should be shown.

### shouldScrollToField
Predicate to decide when the view should scroll to a field.

## motivation

### shouldShowFieldError
### shouldShowFieldWarning

Now our FinalForm shows error-messages on fields only when the field is invalid and the field has been touched. Currently there is no api to change this behaviour. In some situation we might show errors instantly, for example  when an invalid  form is opened. This is now possible.

### shouldScrollToField

When a Form with invalid fields is opened by the user, it might be the case, that the form has many fields, where some are valid and some are invalid. Invalid fields might not be visible inside the viewport when the form is very big. Now it's possible to scroll to the invalid field.



