### PR TITLE
Remove Semicolon from RouterTabs

### DIFF
--- a/packages/admin/src/tabs/RouterTabs.tsx
+++ b/packages/admin/src/tabs/RouterTabs.tsx
@@ -115,7 +115,7 @@ function RouterTabs({
                                 if (match) {
                                     return (
                                         <StackBreadcrumb url={`${match.url}${child.props.path}`} title={child.props.label} invisible={true}>
-                                            <div className={classes.content}>{child.props.children}</div>;
+                                            <div className={classes.content}>{child.props.children}</div>
                                         </StackBreadcrumb>
                                     );
                                 } else {


### PR DESCRIPTION
Remove unneeded semicolon from JSX markup. At the moment, this semicolon is rendered at the bottom of every RouterTabs:

<img width="496" alt="Bildschirmfoto 2021-07-19 um 13 21 17" src="https://user-images.githubusercontent.com/13380047/126152887-a57b39a5-d129-416c-ba61-aa21da74f2dd.png">
