### PR TITLE
Allow Undefined, Null and Boolean in RouterTabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file. This projec
 -   Add `open` and `onOpenChange` props to `AppHeaderDropdown` that allow replacing the internal open state with an external state
 -   add `getTargetUrl()` to `StackSwitchApi`
 -   add `StackLink` component for navigating within a `Stack` via hyperlinks
+-   allow `boolean | undefined | null` as children of `RouterTabs`
 
 ### Incompatible Changes
 

--- a/packages/admin-stories/src/admin/stack/RouterTabsNestedStack.tsx
+++ b/packages/admin-stories/src/admin/stack/RouterTabsNestedStack.tsx
@@ -6,17 +6,8 @@ import * as React from "react";
 import { storyRouterDecorator } from "../../story-router.decorator";
 
 function Story() {
-    const [state, setState] = React.useState<boolean>(true);
-
     return (
         <Stack topLevelTitle="Root Stack">
-            <Button
-                onClick={() => {
-                    setState((prevState) => !prevState);
-                }}
-            >
-                Toggle
-            </Button>
             <StackBreadcrumbs />
             <RouterTabs>
                 <RouterTab label="Page 1" path="">
@@ -42,11 +33,6 @@ function Story() {
                         </StackSwitch>
                     </Stack>
                 </RouterTab>
-                {state && (
-                    <RouterTab label="Mid Page" path="/mid-page">
-                        Mid Page
-                    </RouterTab>
-                )}
                 <RouterTab label="Page 2" path="/page2">
                     Page 2
                 </RouterTab>

--- a/packages/admin-stories/src/admin/stack/RouterTabsNestedStack.tsx
+++ b/packages/admin-stories/src/admin/stack/RouterTabsNestedStack.tsx
@@ -6,8 +6,17 @@ import * as React from "react";
 import { storyRouterDecorator } from "../../story-router.decorator";
 
 function Story() {
+    const [state, setState] = React.useState<boolean>(true);
+
     return (
         <Stack topLevelTitle="Root Stack">
+            <Button
+                onClick={() => {
+                    setState((prevState) => !prevState);
+                }}
+            >
+                Toggle
+            </Button>
             <StackBreadcrumbs />
             <RouterTabs>
                 <RouterTab label="Page 1" path="">
@@ -33,6 +42,11 @@ function Story() {
                         </StackSwitch>
                     </Stack>
                 </RouterTab>
+                {state && (
+                    <RouterTab label="Mid Page" path="/mid-page">
+                        Mid Page
+                    </RouterTab>
+                )}
                 <RouterTab label="Page 2" path="/page2">
                     Page 2
                 </RouterTab>

--- a/packages/admin/src/tabs/RouterTabs.tsx
+++ b/packages/admin/src/tabs/RouterTabs.tsx
@@ -19,7 +19,7 @@ interface TabProps extends MuiTabProps {
 export const RouterTab: React.SFC<TabProps> = () => null;
 
 interface Props extends RouteComponentProps {
-    children: Array<React.ReactElement<TabProps>> | React.ReactElement<TabProps>;
+    children: Array<React.ReactElement<TabProps> | boolean | null | undefined> | React.ReactElement<TabProps>;
     tabComponent?: React.ComponentType<MuiTabProps>;
     tabsProps?: Partial<TabsProps>;
 }
@@ -34,14 +34,16 @@ function RouterTabs({
 }: Props & StyledComponentProps<CometAdminRouterTabsClassKeys>) {
     const classes = mergeClasses<CometAdminRouterTabsClassKeys>(useStyles(), passedClasses);
 
+    const childrenArr = React.Children.toArray(children);
+
     const handleChange = (event: {}, value: number) => {
-        const paths = React.Children.map(children, (child) => {
+        const paths = childrenArr.map((child) => {
             return React.isValidElement<TabProps>(child) ? child.props.path : null;
         });
         history.push(match.url + paths[value]);
     };
 
-    const paths = React.Children.map(children, (child) => {
+    const paths = childrenArr.map((child) => {
         // as seen in https://github.com/mui-org/material-ui/blob/v4.11.0/packages/material-ui/src/Tabs/Tabs.js#L390
         if (!React.isValidElement<TabProps>(child)) {
             return null;


### PR DESCRIPTION
Motivation is doing something like this:

```tsx
<RouterTabs>
    <RouterTab label="Page 1" path="">
        Page 1
    </RouterTab>
    {/*This was not possible before*/}
    {state && (
        <RouterTab label="Optional Page" path="/optional-page">
            Optional Page
        </RouterTab>
    )}
    <RouterTab label="Page 2" path="/page2">
        Page 2
    </RouterTab>
</RouterTabs>
```