### PR TITLE
StackLink Child Props

### DIFF
--- a/packages/admin-stories/src/admin/stack/StackLink.tsx
+++ b/packages/admin-stories/src/admin/stack/StackLink.tsx
@@ -1,0 +1,44 @@
+import { MuiThemeProvider, Stack, StackLink, StackPage, StackSwitch } from "@comet/admin";
+import { createCometTheme } from "@comet/admin-theme";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+
+import { storyRouterDecorator } from "../../story-router.decorator";
+
+const theme = createCometTheme({
+    overrides: {
+        CometAdminStackLink: {
+            root: {
+                padding: "10px",
+                border: "solid black 1px",
+            },
+        },
+    },
+});
+
+function Story() {
+    return (
+        <MuiThemeProvider theme={theme}>
+            <Stack topLevelTitle="Example Stack with StackLinks">
+                <StackSwitch>
+                    <StackPage name="page1">
+                        <h3>Page 1</h3>
+                        <StackLink color="secondary" pageName="page2" payload="test">
+                            link with secondary color
+                        </StackLink>
+                    </StackPage>
+                    <StackPage name="page2">
+                        <h3>Page 2</h3>
+                        <StackLink underline="none" pageName="page1" payload="test">
+                            link to page1
+                        </StackLink>
+                    </StackPage>
+                </StackSwitch>
+            </Stack>
+        </MuiThemeProvider>
+    );
+}
+
+storiesOf("@comet/admin/stack", module)
+    .addDecorator(storyRouterDecorator())
+    .add("StackLink", () => <Story />);

--- a/packages/admin-stories/src/admin/stack/StackLink.tsx
+++ b/packages/admin-stories/src/admin/stack/StackLink.tsx
@@ -2,27 +2,33 @@ import { Stack, StackLink, StackPage, StackSwitch } from "@comet/admin";
 import { Button, Link } from "@material-ui/core";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
+import { useLocation } from "react-router";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
 function Story() {
+    const location = useLocation();
+
     return (
-        <Stack topLevelTitle="Example Stack with StackLinks">
-            <StackSwitch>
-                <StackPage name="page1">
-                    <h3>Page 1</h3>
-                    <Link component={StackLink} pageName="page2" payload="test">
-                        link based on StackLink
-                    </Link>
-                </StackPage>
-                <StackPage name="page2">
-                    <h3>Page 2</h3>
-                    <Button component={StackLink} pageName="page1" payload="test">
-                        button based on StackLink
-                    </Button>
-                </StackPage>
-            </StackSwitch>
-        </Stack>
+        <>
+            <p>Pathname: {location.pathname}</p>
+            <Stack topLevelTitle="Example Stack with StackLinks">
+                <StackSwitch>
+                    <StackPage name="page1">
+                        <h3>Page 1</h3>
+                        <Link component={StackLink} pageName="page2" payload="test">
+                            link based on StackLink
+                        </Link>
+                    </StackPage>
+                    <StackPage name="page2">
+                        <h3>Page 2</h3>
+                        <Button component={StackLink} pageName="page1" payload="test">
+                            button based on StackLink
+                        </Button>
+                    </StackPage>
+                </StackSwitch>
+            </Stack>
+        </>
     );
 }
 

--- a/packages/admin-stories/src/admin/stack/StackLink.tsx
+++ b/packages/admin-stories/src/admin/stack/StackLink.tsx
@@ -1,41 +1,28 @@
-import { MuiThemeProvider, Stack, StackLink, StackPage, StackSwitch } from "@comet/admin";
-import { createCometTheme } from "@comet/admin-theme";
+import { Stack, StackLink, StackPage, StackSwitch } from "@comet/admin";
+import { Button, Link } from "@material-ui/core";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
 
 import { storyRouterDecorator } from "../../story-router.decorator";
 
-const theme = createCometTheme({
-    overrides: {
-        CometAdminStackLink: {
-            root: {
-                padding: "10px",
-                border: "solid black 1px",
-            },
-        },
-    },
-});
-
 function Story() {
     return (
-        <MuiThemeProvider theme={theme}>
-            <Stack topLevelTitle="Example Stack with StackLinks">
-                <StackSwitch>
-                    <StackPage name="page1">
-                        <h3>Page 1</h3>
-                        <StackLink color="secondary" pageName="page2" payload="test">
-                            link with secondary color
-                        </StackLink>
-                    </StackPage>
-                    <StackPage name="page2">
-                        <h3>Page 2</h3>
-                        <StackLink underline="none" pageName="page1" payload="test">
-                            link to page1
-                        </StackLink>
-                    </StackPage>
-                </StackSwitch>
-            </Stack>
-        </MuiThemeProvider>
+        <Stack topLevelTitle="Example Stack with StackLinks">
+            <StackSwitch>
+                <StackPage name="page1">
+                    <h3>Page 1</h3>
+                    <Link component={StackLink} pageName="page2" payload="test">
+                        link based on StackLink
+                    </Link>
+                </StackPage>
+                <StackPage name="page2">
+                    <h3>Page 2</h3>
+                    <Button component={StackLink} pageName="page1" payload="test">
+                        button based on StackLink
+                    </Button>
+                </StackPage>
+            </StackSwitch>
+        </Stack>
     );
 }
 

--- a/packages/admin/src/stack/StackLink.tsx
+++ b/packages/admin/src/stack/StackLink.tsx
@@ -1,61 +1,30 @@
-import { Link, LinkBaseProps as MuiLinkBaseProps } from "@material-ui/core";
-import { TypographyProps } from "@material-ui/core/Typography";
-import { createStyles, WithStyles, withStyles } from "@material-ui/styles";
 import React, { PropsWithChildren } from "react";
 import { Link as RouterLink, LinkProps as RouterLinkProps } from "react-router-dom";
 
 import { IStackSwitchApi, useStackSwitchApi } from "./Switch";
 
-type LinkProps = Omit<RouterLinkProps, "to"> &
-    Omit<MuiLinkBaseProps, "component"> & {
-        TypographyClasses?: TypographyProps["classes"];
-        underline?: "none" | "hover" | "always";
-    };
-
-interface StackLinkProps extends LinkProps {
+interface StackLinkProps extends Omit<RouterLinkProps, "to"> {
     pageName: string;
     payload: string;
     subUrl?: string;
     switchApi?: IStackSwitchApi;
 }
 
-type CometAdminStackLinkClassKeys = "root";
-
-const styles = () =>
-    createStyles<CometAdminStackLinkClassKeys, any>({
-        root: {},
-    });
-
-const StackLinkWithoutStyles = ({
-    classes,
+export const StackLink = ({
     pageName,
     payload,
     subUrl,
     switchApi: externalSwitchApi,
     children,
     ...props
-}: WithStyles<typeof styles, false> & PropsWithChildren<StackLinkProps>): React.ReactElement => {
+}: PropsWithChildren<StackLinkProps>): React.ReactElement => {
     const internalSwitchApi = useStackSwitchApi();
     // external switchApi allows the creation of StackLinks outside of the stack with the useStackSwitch() hook
     const _switchApi = externalSwitchApi !== undefined ? externalSwitchApi : internalSwitchApi;
 
     return (
-        <Link classes={{ root: classes.root }} to={() => _switchApi.getTargetUrl(pageName, payload, subUrl)} component={RouterLink} {...props}>
+        <RouterLink to={() => _switchApi.getTargetUrl(pageName, payload, subUrl)} {...props}>
             {children}
-        </Link>
+        </RouterLink>
     );
 };
-
-export const StackLink = withStyles(styles, { name: "CometAdminStackLink" })(StackLinkWithoutStyles);
-
-declare module "@material-ui/core/styles/overrides" {
-    interface ComponentNameToClassKey {
-        CometAdminStackLink: CometAdminStackLinkClassKeys;
-    }
-}
-
-declare module "@material-ui/core/styles/props" {
-    interface ComponentsPropsList {
-        CometAdminStackLink: PropsWithChildren<StackLinkProps>;
-    }
-}

--- a/packages/admin/src/stack/StackLink.tsx
+++ b/packages/admin/src/stack/StackLink.tsx
@@ -1,30 +1,61 @@
-import { Link } from "@material-ui/core";
+import { Link, LinkBaseProps as MuiLinkBaseProps } from "@material-ui/core";
+import { TypographyProps } from "@material-ui/core/Typography";
+import { createStyles, WithStyles, withStyles } from "@material-ui/styles";
 import React, { PropsWithChildren } from "react";
-import { Link as RouterLink } from "react-router-dom";
+import { Link as RouterLink, LinkProps as RouterLinkProps } from "react-router-dom";
 
 import { IStackSwitchApi, useStackSwitchApi } from "./Switch";
 
-interface StackLinkProps {
+type LinkProps = Omit<RouterLinkProps, "to"> &
+    Omit<MuiLinkBaseProps, "component"> & {
+        TypographyClasses?: TypographyProps["classes"];
+        underline?: "none" | "hover" | "always";
+    };
+
+interface StackLinkProps extends LinkProps {
     pageName: string;
     payload: string;
     subUrl?: string;
     switchApi?: IStackSwitchApi;
 }
 
-export const StackLink = ({
+type CometAdminStackLinkClassKeys = "root";
+
+const styles = () =>
+    createStyles<CometAdminStackLinkClassKeys, any>({
+        root: {},
+    });
+
+const StackLinkWithoutStyles = ({
+    classes,
     pageName,
     payload,
     subUrl,
     switchApi: externalSwitchApi,
     children,
-}: PropsWithChildren<StackLinkProps>): React.ReactElement => {
+    ...props
+}: WithStyles<typeof styles, false> & PropsWithChildren<StackLinkProps>): React.ReactElement => {
     const internalSwitchApi = useStackSwitchApi();
     // external switchApi allows the creation of StackLinks outside of the stack with the useStackSwitch() hook
     const _switchApi = externalSwitchApi !== undefined ? externalSwitchApi : internalSwitchApi;
 
     return (
-        <Link to={() => _switchApi.getTargetUrl(pageName, payload, subUrl)} component={RouterLink}>
+        <Link classes={{ root: classes.root }} to={() => _switchApi.getTargetUrl(pageName, payload, subUrl)} component={RouterLink} {...props}>
             {children}
         </Link>
     );
 };
+
+export const StackLink = withStyles(styles, { name: "CometAdminStackLink" })(StackLinkWithoutStyles);
+
+declare module "@material-ui/core/styles/overrides" {
+    interface ComponentNameToClassKey {
+        CometAdminStackLink: CometAdminStackLinkClassKeys;
+    }
+}
+
+declare module "@material-ui/core/styles/props" {
+    interface ComponentsPropsList {
+        CometAdminStackLink: PropsWithChildren<StackLinkProps>;
+    }
+}


### PR DESCRIPTION
- Allow override of `StackLink` styling via theme
- Take props of `MuiLink` and `RouterLink` and pass them on