### PR TITLE
 Export selectionApi from useEditDialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file. This projec
 -   add `getTargetUrl()` to `StackSwitchApi`
 -   add `StackLink` component for navigating within a `Stack` via hyperlinks
 -   allow `boolean | undefined | null` as children of `RouterTabs`
+-   expose `selectionApi` through `useEditDialog`
 
 ### Incompatible Changes
 

--- a/packages/admin-stories/src/admin/edit-dialog/EditDialogWithFormInStack.tsx
+++ b/packages/admin-stories/src/admin/edit-dialog/EditDialogWithFormInStack.tsx
@@ -6,75 +6,88 @@ import * as React from "react";
 import { apolloStoryDecorator } from "../../apollo-story.decorator";
 import { storyRouterDecorator } from "../../story-router.decorator";
 
+interface RootPageProps {
+    counter: number;
+}
+
+const RootPage = ({ counter }: RootPageProps): React.ReactElement => {
+    const [EditDialog, selection, editDialogApi, selectionApi] = useEditDialog();
+
+    return (
+        <>
+            <StackBreadcrumbs />
+            <h1>Nested Site {counter}</h1>
+            <p>
+                Go at least one page down.
+                <ul>
+                    <li>When using the &apos;Open Dialog Without Deselect&apos;, the stack goes back one page after pressing enter</li>
+                    <li>When using the new &apos;Open Dialog With Deselect&apos;, the stack doesn&apos;t go back</li>
+                </ul>
+            </p>
+            <p>
+                <StackLink pageName="nested" payload={String(counter + 1)}>
+                    To next page
+                </StackLink>
+            </p>
+            <p>
+                <Button
+                    onClick={() => {
+                        editDialogApi.openAddDialog("without_deselect");
+                    }}
+                >
+                    Open Dialog Without Deselect (old)
+                </Button>
+            </p>
+            <p>
+                <Button
+                    onClick={() => {
+                        editDialogApi.openAddDialog("with_deselect");
+                    }}
+                >
+                    Open Dialog With Deselect (new)
+                </Button>
+            </p>
+            <EditDialog>
+                {selection.id === "without_deselect" && (
+                    <FinalForm
+                        mode={selection.mode!}
+                        onSubmit={async () => {
+                            console.log("submitted without deselect");
+                        }}
+                    >
+                        <Field label="Write something and press enter" name="field" component={FinalFormInput} required />
+                    </FinalForm>
+                )}
+                {selection.id === "with_deselect" && (
+                    <FinalForm
+                        mode={selection.mode!}
+                        onSubmit={async () => {
+                            console.log("submitted with deselect");
+                        }}
+                        onAfterSubmit={() => {
+                            // override stackApi.goBack()
+                            selectionApi.handleDeselect();
+                        }}
+                    >
+                        <Field label="Write something and press enter" name="field" component={FinalFormInput} required />
+                    </FinalForm>
+                )}
+            </EditDialog>
+        </>
+    );
+};
+
 interface InnerNestedStackProps {
     counter: number;
 }
 
 const InnerNestedStack = ({ counter }: InnerNestedStackProps) => {
     const [nestedCounter, setNestedCounter] = React.useState<number>();
-    const [EditDialog, selection, editDialogApi, selectionApi] = useEditDialog();
 
     return (
         <StackSwitch initialPage="root">
             <StackPage name="root">
-                <StackBreadcrumbs />
-                <h1>Nested Site {counter}</h1>
-                <p>
-                    Go at least one page down.
-                    <ul>
-                        <li>When using the &apos;Open Dialog Without Deselect&apos;, the stack goes back one page after pressing enter</li>
-                        <li>When using the new &apos;Open Dialog With Deselect&apos;, the stack doesn&apos;t go back</li>
-                    </ul>
-                </p>
-                <p>
-                    <StackLink pageName="nested" payload={String(counter + 1)}>
-                        To next page
-                    </StackLink>
-                </p>
-                <p>
-                    <Button
-                        onClick={() => {
-                            editDialogApi.openAddDialog("without_deselect");
-                        }}
-                    >
-                        Open Dialog Without Deselect (old)
-                    </Button>
-                </p>
-                <p>
-                    <Button
-                        onClick={() => {
-                            editDialogApi.openAddDialog("with_deselect");
-                        }}
-                    >
-                        Open Dialog With Deselect (new)
-                    </Button>
-                </p>
-                <EditDialog>
-                    {selection.id === "without_deselect" && (
-                        <FinalForm
-                            mode={selection.mode!}
-                            onSubmit={async () => {
-                                console.log("submitted without deselect");
-                            }}
-                        >
-                            <Field label="Write something and press enter" name="field" component={FinalFormInput} required />
-                        </FinalForm>
-                    )}
-                    {selection.id === "with_deselect" && (
-                        <FinalForm
-                            mode={selection.mode!}
-                            onSubmit={async () => {
-                                console.log("submitted with deselect");
-                            }}
-                            onAfterSubmit={() => {
-                                // override stackApi.goBack()
-                                selectionApi.handleDeselect();
-                            }}
-                        >
-                            <Field label="Write something and press enter" name="field" component={FinalFormInput} required />
-                        </FinalForm>
-                    )}
-                </EditDialog>
+                <RootPage counter={counter} />
             </StackPage>
             <StackPage name="nested" title={`Page ${nestedCounter}`}>
                 {(counter) => {

--- a/packages/admin-stories/src/admin/edit-dialog/EditDialogWithFormInStack.tsx
+++ b/packages/admin-stories/src/admin/edit-dialog/EditDialogWithFormInStack.tsx
@@ -1,0 +1,100 @@
+import { Field, FinalForm, FinalFormInput, Stack, StackBreadcrumbs, StackLink, StackPage, StackSwitch, useEditDialog } from "@comet/admin";
+import { Button } from "@material-ui/core";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+
+import { apolloStoryDecorator } from "../../apollo-story.decorator";
+import { storyRouterDecorator } from "../../story-router.decorator";
+
+interface InnerNestedStackProps {
+    counter: number;
+}
+
+const InnerNestedStack = ({ counter }: InnerNestedStackProps) => {
+    const [nestedCounter, setNestedCounter] = React.useState<number>();
+    const [EditDialog, selection, editDialogApi, selectionApi] = useEditDialog();
+
+    return (
+        <StackSwitch initialPage="root">
+            <StackPage name="root">
+                <StackBreadcrumbs />
+                <h1>Nested Site {counter}</h1>
+                <p>
+                    Go at least one page down.
+                    <ul>
+                        <li>When using the &apos;Open Dialog Without Deselect&apos;, the stack goes back one page after pressing enter</li>
+                        <li>When using the new &apos;Open Dialog With Deselect&apos;, the stack doesn&apos;t go back</li>
+                    </ul>
+                </p>
+                <p>
+                    <StackLink pageName="nested" payload={String(counter + 1)}>
+                        To next page
+                    </StackLink>
+                </p>
+                <p>
+                    <Button
+                        onClick={() => {
+                            editDialogApi.openAddDialog("without_deselect");
+                        }}
+                    >
+                        Open Dialog Without Deselect (old)
+                    </Button>
+                </p>
+                <p>
+                    <Button
+                        onClick={() => {
+                            editDialogApi.openAddDialog("with_deselect");
+                        }}
+                    >
+                        Open Dialog With Deselect (new)
+                    </Button>
+                </p>
+                <EditDialog>
+                    {selection.id === "without_deselect" && (
+                        <FinalForm
+                            mode={selection.mode!}
+                            onSubmit={async () => {
+                                console.log("submitted without deselect");
+                            }}
+                        >
+                            <Field label="Write something and press enter" name="field" component={FinalFormInput} required />
+                        </FinalForm>
+                    )}
+                    {selection.id === "with_deselect" && (
+                        <FinalForm
+                            mode={selection.mode!}
+                            onSubmit={async () => {
+                                console.log("submitted with deselect");
+                            }}
+                            onAfterSubmit={() => {
+                                // override stackApi.goBack()
+                                selectionApi.handleDeselect();
+                            }}
+                        >
+                            <Field label="Write something and press enter" name="field" component={FinalFormInput} required />
+                        </FinalForm>
+                    )}
+                </EditDialog>
+            </StackPage>
+            <StackPage name="nested" title={`Page ${nestedCounter}`}>
+                {(counter) => {
+                    setNestedCounter(Number(counter));
+                    return <InnerNestedStack counter={Number(counter)} />;
+                }}
+            </StackPage>
+        </StackSwitch>
+    );
+};
+
+function Story() {
+    return (
+        <Stack topLevelTitle="Page 1">
+            <InnerNestedStack counter={1} />
+        </Stack>
+    );
+}
+
+storiesOf("@comet/admin/edit-dialog", module)
+    .addDecorator(storyRouterDecorator())
+    .addDecorator(apolloStoryDecorator())
+    .add("Edit Dialog with Form in Stack", () => <Story />);

--- a/packages/admin/src/EditDialog.tsx
+++ b/packages/admin/src/EditDialog.tsx
@@ -32,7 +32,7 @@ const messages = defineMessages({
     },
 });
 
-export function useEditDialog(): [React.ComponentType<IProps>, { id?: string; mode?: "edit" | "add" }, IEditDialogApi] {
+export function useEditDialog(): [React.ComponentType<IProps>, { id?: string; mode?: "edit" | "add" }, IEditDialogApi, ISelectionApi] {
     const [Selection, selection, selectionApi] = useSelectionRoute();
 
     const openAddDialog = React.useCallback(
@@ -66,7 +66,7 @@ export function useEditDialog(): [React.ComponentType<IProps>, { id?: string; mo
         };
     }, [Selection, api, selection, selectionApi]);
 
-    return [EditDialogWithHookProps, selection, api];
+    return [EditDialogWithHookProps, selection, api, selectionApi];
 }
 
 interface IHookProps {


### PR DESCRIPTION
Suggestion for handling issue https://github.com/vivid-planet/comet-admin/issues/444

Per default, if there is a form in an EditDialog and it's submitted by pressing enter, the stack goes back one page after submitting.

The reason is this code:

```tsx
// https://github.com/vivid-planet/comet-admin/blob/next/packages/admin/src/FinalForm.tsx#L40
onAfterSubmit = () => {
    stackApi?.goBack();
},
```

If `onAfterSubmit` is overwritten in the form, it doesn't close at all when submitting with Enter. The reason is, that the selection is not deselected. This is done inside `handleSaveClick` (https://github.com/vivid-planet/comet-admin/blob/next/packages/admin/src/EditDialog.tsx#L97) and `handleCancelClick` (https://github.com/vivid-planet/comet-admin/blob/next/packages/admin/src/EditDialog.tsx#L105) inside the EditDialog. But submitting via Enter doesn't trigger any of them.

The issue can be resolved by exporting the selectionApi from useEditDialog. Then `onAfterSubmit` has to be overwritten in the `FinalForm` and the `handleDeselect` has to be triggered manually inside this method:

```tsx
<FinalForm
    // ...
    onAfterSubmit={() => {
        // override stackApi.goBack()
        selectionApi.handleDeselect();
    }}
>
    // ...
</FinalForm>
```

I also added a demo story displaying the broken and the fixed way.
