### PR TITLE
Add lower bound to PrettyBytes

### DIFF
--- a/packages/admin-stories/src/admin/helpers/PrettyBytes.tsx
+++ b/packages/admin-stories/src/admin/helpers/PrettyBytes.tsx
@@ -18,29 +18,33 @@ function Normal() {
                     Normal Behavior
                 </Typography>
                 <Content>
-                    <span>6 Bytes</span>{" "}
+                    <span>0 Bytes</span>
                     <span>
-                        <PrettyBytes value={6} />{" "}
+                        <PrettyBytes value={0} />
                     </span>
-                    <span>6.000 Bytes</span>{" "}
+                    <span>6 Bytes</span>
                     <span>
-                        <PrettyBytes value={6000} />{" "}
+                        <PrettyBytes value={6} />
                     </span>
-                    <span>6.000.000 Bytes</span>{" "}
+                    <span>6.000 Bytes</span>
                     <span>
-                        <PrettyBytes value={6000000} />{" "}
+                        <PrettyBytes value={6000} />
                     </span>
-                    <span>6.000.000.000 Bytes</span>{" "}
+                    <span>6.000.000 Bytes</span>
                     <span>
-                        <PrettyBytes value={6000000000} />{" "}
+                        <PrettyBytes value={6000000} />
                     </span>
-                    <span>6.000.000.000.000 Bytes</span>{" "}
+                    <span>6.000.000.000 Bytes</span>
                     <span>
-                        <PrettyBytes value={6000000000000} />{" "}
+                        <PrettyBytes value={6000000000} />
                     </span>
-                    <span>6.000.000.000.000.000 Bytes</span>{" "}
+                    <span>6.000.000.000.000 Bytes</span>
                     <span>
-                        <PrettyBytes value={6000000000000000} />{" "}
+                        <PrettyBytes value={6000000000000} />
+                    </span>
+                    <span>6.000.000.000.000.000 Bytes</span>
+                    <span>
+                        <PrettyBytes value={6000000000000000} />
                     </span>
                 </Content>
             </CardContent>
@@ -56,29 +60,33 @@ function FixedUnit() {
                     Fixed Unit (kilobyte)
                 </Typography>
                 <Content>
+                    <span>0 Bytes</span>
+                    <span>
+                        <PrettyBytes value={0} unit="kilobyte" />
+                    </span>
                     <span>6 Bytes</span>
                     <span>
-                        <PrettyBytes value={6} unit="kilobyte" />{" "}
+                        <PrettyBytes value={6} unit="kilobyte" />
                     </span>
-                    <span>6.000 Bytes</span>{" "}
+                    <span>6.000 Bytes</span>
                     <span>
-                        <PrettyBytes value={6000} unit="kilobyte" />{" "}
+                        <PrettyBytes value={6000} unit="kilobyte" />
                     </span>
-                    <span>6.000.000 Bytes</span>{" "}
+                    <span>6.000.000 Bytes</span>
                     <span>
-                        <PrettyBytes value={6000000} unit="kilobyte" />{" "}
+                        <PrettyBytes value={6000000} unit="kilobyte" />
                     </span>
-                    <span>6.000.000.000 Bytes</span>{" "}
+                    <span>6.000.000.000 Bytes</span>
                     <span>
-                        <PrettyBytes value={6000000000} unit="kilobyte" />{" "}
+                        <PrettyBytes value={6000000000} unit="kilobyte" />
                     </span>
-                    <span>6.000.000.000.000 Bytes</span>{" "}
+                    <span>6.000.000.000.000 Bytes</span>
                     <span>
-                        <PrettyBytes value={6000000000000} unit="kilobyte" />{" "}
+                        <PrettyBytes value={6000000000000} unit="kilobyte" />
                     </span>
-                    <span>6.000.000.000.000.000 Bytes</span>{" "}
+                    <span>6.000.000.000.000.000 Bytes</span>
                     <span>
-                        <PrettyBytes value={6000000000000000} unit="kilobyte" />{" "}
+                        <PrettyBytes value={6000000000000000} unit="kilobyte" />
                     </span>
                 </Content>
             </CardContent>
@@ -94,29 +102,33 @@ function CustomMaximumFractionDigits() {
                     Custom maximumFractionDigits (6 digits)
                 </Typography>
                 <Content>
-                    <span>6 Bytes</span>{" "}
+                    <span>0 Bytes</span>
                     <span>
-                        <PrettyBytes value={6} unit="megabyte" maximumFractionDigits={6} />{" "}
+                        <PrettyBytes value={0} unit="megabyte" maximumFractionDigits={6} />
                     </span>
-                    <span>6.000 Bytes</span>{" "}
+                    <span>6 Bytes</span>
                     <span>
-                        <PrettyBytes value={6000} unit="megabyte" maximumFractionDigits={6} />{" "}
+                        <PrettyBytes value={6} unit="megabyte" maximumFractionDigits={6} />
                     </span>
-                    <span>6.000.000 Bytes</span>{" "}
+                    <span>6.000 Bytes</span>
                     <span>
-                        <PrettyBytes value={6000000} unit="megabyte" maximumFractionDigits={6} />{" "}
+                        <PrettyBytes value={6000} unit="megabyte" maximumFractionDigits={6} />
                     </span>
-                    <span>6.000.000.000 Bytes</span>{" "}
+                    <span>6.000.000 Bytes</span>
                     <span>
-                        <PrettyBytes value={6000000000} unit="megabyte" maximumFractionDigits={6} />{" "}
+                        <PrettyBytes value={6000000} unit="megabyte" maximumFractionDigits={6} />
                     </span>
-                    <span>6.000.000.000.000 Bytes</span>{" "}
+                    <span>6.000.000.000 Bytes</span>
                     <span>
-                        <PrettyBytes value={6000000000000} unit="megabyte" maximumFractionDigits={6} />{" "}
+                        <PrettyBytes value={6000000000} unit="megabyte" maximumFractionDigits={6} />
                     </span>
-                    <span>6.000.000.000.000.000 Bytes</span>{" "}
+                    <span>6.000.000.000.000 Bytes</span>
                     <span>
-                        <PrettyBytes value={6000000000000000} unit="megabyte" maximumFractionDigits={6} />{" "}
+                        <PrettyBytes value={6000000000000} unit="megabyte" maximumFractionDigits={6} />
+                    </span>
+                    <span>6.000.000.000.000.000 Bytes</span>
+                    <span>
+                        <PrettyBytes value={6000000000000000} unit="megabyte" maximumFractionDigits={6} />
                     </span>
                 </Content>
             </CardContent>

--- a/packages/admin/src/helpers/PrettyBytes.tsx
+++ b/packages/admin/src/helpers/PrettyBytes.tsx
@@ -23,7 +23,10 @@ export const PrettyBytes = ({
         // log to base 1024
         // => receive exponent of equation `1024 ** exponent = bytes`
         // => exponent determines unit
-        exponent = Math.min(Math.floor(Math.log(Math.abs(bytes)) / Math.log(1024)), availableUnits.length - 1);
+        exponent = Math.floor(Math.log(Math.abs(bytes)) / Math.log(1024));
+        // upper and lower bounds => exponent cannot be outside range of availableUnits
+        exponent = Math.min(exponent, availableUnits.length - 1);
+        exponent = Math.max(exponent, 0);
     }
     const unit = availableUnits[exponent];
     const size = bytes / 1024 ** exponent;


### PR DESCRIPTION
The exponent in PrettyBytes didn't have a lower bound before. Therefore, when using `<PrettyBytes value={0} />`, the exponent was `-Infinity` resulting in `NaN`.

This PR adds a lower bound that prevents the exponent from being smaller than 0