### PR TITLE
Add memory router with prompt

### DIFF
--- a/packages/admin-stories/src/story-router.decorator.tsx
+++ b/packages/admin-stories/src/story-router.decorator.tsx
@@ -1,14 +1,15 @@
+import { RouterMemoryRouter } from "@comet/admin";
 import { action } from "@storybook/addon-actions";
 import { StoryContext, StoryFn } from "@storybook/addons";
 import { Action, History, UnregisterCallback } from "history";
 import * as React from "react";
-import { MemoryRouter, MemoryRouterProps, Route, RouteComponentProps } from "react-router";
+import { MemoryRouterProps, Route, RouteComponentProps } from "react-router";
 
 const StoryRouter = ({ children, routerProps }: { children: React.ReactNode; routerProps?: MemoryRouterProps }) => {
     return (
-        <MemoryRouter {...routerProps}>
+        <RouterMemoryRouter {...routerProps}>
             <Route render={(props) => <HistoryWatcher {...props}>{children}</HistoryWatcher>} />
-        </MemoryRouter>
+        </RouterMemoryRouter>
     );
 };
 

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -1,5 +1,6 @@
 export { IWindowSize, useWindowSize } from "./helpers/useWindowSize";
 export { RouterBrowserRouter } from "./router/BrowserRouter";
+export { RouterMemoryRouter } from "./router/MemoryRouter";
 export { RouterConfirmationDialog } from "./router/ConfirmationDialog";
 export { RouterContext } from "./router/Context";
 export { RouterPrompt } from "./router/Prompt";

--- a/packages/admin/src/router/MemoryRouter.tsx
+++ b/packages/admin/src/router/MemoryRouter.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import { MemoryRouter as ReactMemoryRouter, MemoryRouterProps } from "react-router-dom";
+
+import { RouterConfirmationDialog } from "./ConfirmationDialog";
+import { RouterPromptHandler } from "./PromptHandler";
+
+// MemoryRouter that sets up a material-ui confirmation dialog
+// plus a PromptHandler that works with our Prompt (supporting multiple Prompts)
+
+interface IState {
+    showConfirmationDialog: boolean;
+    message: string;
+    callback?: (ok: boolean) => void;
+}
+
+export const RouterMemoryRouter: React.FunctionComponent<MemoryRouterProps> = ({ children, ...props }) => {
+    const [state, setState] = React.useState<IState>({
+        showConfirmationDialog: false,
+        message: "",
+        callback: undefined,
+    });
+    const getConfirmation = (message: string, callback: (ok: boolean) => void) => {
+        setState({
+            showConfirmationDialog: true,
+            message,
+            callback,
+        });
+    };
+    const handleClose = (allowTransition: boolean) => {
+        if (state.callback) {
+            state.callback(allowTransition);
+        }
+        setState({
+            showConfirmationDialog: false,
+            message: "",
+            callback: undefined,
+        });
+    };
+
+    return (
+        <ReactMemoryRouter getUserConfirmation={getConfirmation} {...props}>
+            <RouterPromptHandler>
+                {children}
+                <RouterConfirmationDialog isOpen={state.showConfirmationDialog} message={state.message} handleClose={handleClose} />
+            </RouterPromptHandler>
+        </ReactMemoryRouter>
+    );
+};


### PR DESCRIPTION
This change adds a new `RouterMemoryRouter` component based on the `RouterBrowserRouter` component. Previously, our stories use the `MemoryRouter` from react-router directly, with which our router prompts would not work, and therefore the form dirty handlers would not work either. Using the `RouterMemoryRouter` in our stories causes the form dirty handlers to work correctly.