### PR TITLE
fix: declare globalErrorHandling as own story module due to multiple apolloClientStoryDecorators

### DIFF
--- a/packages/admin-stories/src/admin/table/GlobalErrorHandling.tsx
+++ b/packages/admin-stories/src/admin/table/GlobalErrorHandling.tsx
@@ -68,7 +68,7 @@ const Story: React.FunctionComponent = () => {
     );
 };
 
-storiesOf("@comet/admin/table", module)
+storiesOf("@comet/admin/table/globalErrorHandling", module)
     .addDecorator(apolloSwapiStoryDecorator())
     .addDecorator(errorDialogStoryProviderDecorator())
     .add("Global Error Handling", () => <Story />);


### PR DESCRIPTION
the global  Error Handling Story uses the apolloSwapiStoryDecorator which is a plain graphql api
and the other old stories are using the apolloStoryDecorator which is a rest api

the problem now is that every decorator gets set to the module which was in that case the "@comet/admin/table" story, so multiple apollo client gets set onto it and because the globalErrorHandling story is the first in the table list, every other story below which would need the RestApi uses the Swapi GQL API and throws an error.