### PR TITLE
Add ClearInputButton to FinalFormSearchTextField

### DIFF
--- a/packages/admin/src/form/FinalFormSearchTextField.tsx
+++ b/packages/admin/src/form/FinalFormSearchTextField.tsx
@@ -20,24 +20,26 @@ export interface CometAdminFinalFormSearchTextFieldThemeProps {
     icon?: React.ReactNode;
 }
 
-export function FinalFormSearchTextField({ icon, placeholder, ...restProps }: FinalFormInputProps): React.ReactElement {
+export function FinalFormSearchTextField({ icon, placeholder, endAdornment, ...restProps }: FinalFormInputProps): React.ReactElement {
     const intl = useIntl();
     const themeProps = useThemeProps();
 
     return (
         <FinalFormInput
+            {...restProps}
             placeholder={placeholder ?? intl.formatMessage({ id: "comet.finalformsearchtextfield.default.placeholder", defaultMessage: "Search" })}
             startAdornment={<InputAdornment position="start">{icon ?? themeProps.icon}</InputAdornment>}
             endAdornment={
-                <ClearInputWrapper $hidden={restProps.input.value.length === 0}>
-                    <ClearInputButton
-                        onClick={() => {
-                            restProps.input.onChange("");
-                        }}
-                    />
-                </ClearInputWrapper>
+                endAdornment ?? (
+                    <ClearInputWrapper $hidden={restProps.input.value.length === 0}>
+                        <ClearInputButton
+                            onClick={() => {
+                                restProps.input.onChange("");
+                            }}
+                        />
+                    </ClearInputWrapper>
+                )
             }
-            {...restProps}
         />
     );
 }

--- a/packages/admin/src/form/FinalFormSearchTextField.tsx
+++ b/packages/admin/src/form/FinalFormSearchTextField.tsx
@@ -2,9 +2,19 @@ import { Search } from "@comet/admin-icons";
 import { InputAdornment } from "@material-ui/core";
 import * as React from "react";
 import { useIntl } from "react-intl";
+import styled from "styled-components";
 
+import { ClearInputButton } from "..";
 import { useComponentThemeProps } from "../mui/useComponentThemeProps";
 import { FinalFormInput, FinalFormInputProps } from "./FinalFormInput";
+
+interface ClearInputWrapperProps {
+    $hidden: boolean;
+}
+
+const ClearInputWrapper = styled.div<ClearInputWrapperProps>`
+    visibility: ${({ $hidden }) => ($hidden ? "hidden" : "initial")};
+`;
 
 export interface CometAdminFinalFormSearchTextFieldThemeProps {
     icon?: React.ReactNode;
@@ -16,9 +26,18 @@ export function FinalFormSearchTextField({ icon, placeholder, ...restProps }: Fi
 
     return (
         <FinalFormInput
-            {...restProps}
             placeholder={placeholder ?? intl.formatMessage({ id: "comet.finalformsearchtextfield.default.placeholder", defaultMessage: "Search" })}
             startAdornment={<InputAdornment position="start">{icon ?? themeProps.icon}</InputAdornment>}
+            endAdornment={
+                <ClearInputWrapper $hidden={restProps.input.value.length === 0}>
+                    <ClearInputButton
+                        onClick={() => {
+                            restProps.input.onChange("");
+                        }}
+                    />
+                </ClearInputWrapper>
+            }
+            {...restProps}
         />
     );
 }


### PR DESCRIPTION
- Add ClearInputButton to FinalFormSearchTextField per default
- ClearInputButton is hidden while the search field is empty
- Default endAdornment is overwritten by custom endAdornment