### PR TITLE
Export MasterLayoutContext

### DIFF
--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -82,6 +82,7 @@ export { CometAdminMenuClassKeys, styles } from "./mui/menu/Menu.styles";
 export { IMenuContext, IWithMenu, MenuContext, withMenu } from "./mui/menu/Context";
 export { MuiThemeProvider } from "./mui/ThemeProvider";
 export { MasterLayout, MasterLayoutProps } from "./mui/MasterLayout";
+export { MasterLayoutContext } from "./mui/MasterLayoutContext";
 export { CometAdminMasterLayoutClassKeys } from "./mui/MasterLayout.styles";
 export { CometAdminMainContentClassKeys, MainContent } from "./mui/MainContent";
 export { Toolbar } from "./common/toolbar/Toolbar";


### PR DESCRIPTION
It may be neccessary to access the headerHeight, e.g. when creating a custom header-component.