### PR TITLE
Prevent invalid dom-nesting in Rte BlockElement

### DIFF
--- a/packages/admin-rte/src/core/BlockElement.tsx
+++ b/packages/admin-rte/src/core/BlockElement.tsx
@@ -20,7 +20,7 @@ interface Props extends TypographyProps {
 
 export const BlockElement = ({ classes: passedClasses, type, ...restProps }: Props & StyledComponentProps<CometAdminRteBlockElementClassKeys>) => {
     const classes = mergeClasses<CometAdminRteBlockElementClassKeys>(useStyles(), passedClasses);
-    return <Typography classes={{ root: `${classes.root} ${type ? classes[type] : ""}` }} {...restProps} />;
+    return <Typography component="div" classes={{ root: `${classes.root} ${type ? classes[type] : ""}` }} {...restProps} />;
 };
 
 const useStyles = makeStyles<Theme, {}, CometAdminRteBlockElementClassKeys>(


### PR DESCRIPTION
A div is rendered inside the Typography of BlockElement by draft-js, a div cannot be a decendant of p, h1, etc.