### PR TITLE
Remove input-container min-width

### DIFF
--- a/packages/admin-stories/src/docs/form/Layout.stories.tsx
+++ b/packages/admin-stories/src/docs/form/Layout.stories.tsx
@@ -276,11 +276,13 @@ storiesOf("stories/form/Layout", module)
             <ThemeProvider theme={theme}>
                 <Form
                     onSubmit={() => {}}
+                    initialValues={{ select: "none" }}
                     render={({ handleSubmit }) => (
                         <form onSubmit={handleSubmit}>
                             <Field name="select" label="Select">
                                 {(props) => (
                                     <FinalFormSelect {...props}>
+                                        <MenuItem value="none">No value</MenuItem>
                                         {flavourOptions.map((option) => (
                                             <MenuItem value={option.value} key={option.value}>
                                                 {option.label}

--- a/packages/admin/src/form/FieldContainer.tsx
+++ b/packages/admin/src/form/FieldContainer.tsx
@@ -60,11 +60,7 @@ const styles = (theme: Theme) => {
                 flexGrow: 1,
             },
         },
-        fullWidth: {
-            "& $inputContainer": {
-                minWidth: 0,
-            },
-        },
+        fullWidth: {},
         required: {},
         disabled: {},
         fieldMarginAlways: {},
@@ -78,9 +74,7 @@ const styles = (theme: Theme) => {
             },
         },
         label: {},
-        inputContainer: {
-            minWidth: 120,
-        },
+        inputContainer: {},
         hasError: {
             "& $label:not([class*='Mui-focused'])": {
                 color: theme.palette.error.main,


### PR DESCRIPTION
The original purpose of the min-width was primarily to prevent selects with no value from being very tiny.

Adding the min-width caused selects with short values to be unnecessarily large and to break layouts. 
A better solution would be, to make sure every select, that is not full-width has a default value or placeholder.

![Screenshot 2021-10-05 at 11 25 57](https://user-images.githubusercontent.com/6264317/136007731-4cf21428-083b-437a-a463-53db1086205a.png)