### PR TITLE
Fix height and padding of color-picker

### DIFF
--- a/packages/admin-color-picker/src/core/ColorPicker.styles.ts
+++ b/packages/admin-color-picker/src/core/ColorPicker.styles.ts
@@ -40,13 +40,13 @@ export const styles = (theme: Theme) => {
             alignItems: "center",
             justifyContent: "space-between",
             width: "100%",
+            lineHeight: "20px",
+            padding: 9,
         },
         inputInnerLeftContent: {
             display: "flex",
             flexDirection: "row",
             alignItems: "center",
-            paddingLeft: theme.spacing(1),
-            paddingRight: theme.spacing(1),
             width: "100%",
         },
         popper: {


### PR DESCRIPTION
This was broken in https://github.com/vivid-planet/comet-admin/pull/503.

![Screenshot 2021-10-13 at 12 45 02](https://user-images.githubusercontent.com/6264317/137119238-900b59c3-4747-4bbd-82c5-0ecc52975576.png)