### PR TITLE
Define icon color in ButtonBase

### DIFF
--- a/packages/admin-stories/src/docs/components/ClearInputButton/ClearInputButton.stories.mdx
+++ b/packages/admin-stories/src/docs/components/ClearInputButton/ClearInputButton.stories.mdx
@@ -14,9 +14,9 @@ It lets you specify which ClearIcon you want to display.
 
 ## Props
 
-| Name | Type                                                | Default | Description    |
-| :--- | :-------------------------------------------------- | :------ | :------------- |
-| icon | (disabled?:boolean) => React.ReactNode \| undefined |         | The Clear Icon |
+| Name | Type            | Default | Description    |
+| :--- | :-------------- | :------ | :------------- |
+| icon | React.ReactNode |         | The Clear Icon |
 
 ## CSS
 

--- a/packages/admin-stories/src/docs/components/ClearInputButton/stories/CustomClearIcon.stories.tsx
+++ b/packages/admin-stories/src/docs/components/ClearInputButton/stories/CustomClearIcon.stories.tsx
@@ -13,7 +13,7 @@ storiesOf("stories/components/Clear Input Button/Custom Clear Icon", module).add
             <InputBase
                 endAdornment={
                     <InputAdornment position="end">
-                        <ClearInputButton icon={() => <Cut />} />
+                        <ClearInputButton icon={<Cut />} />
                     </InputAdornment>
                 }
             />

--- a/packages/admin-theme/src/paletteOptions.ts
+++ b/packages/admin-theme/src/paletteOptions.ts
@@ -18,4 +18,8 @@ export const paletteOptions: PaletteOptions = {
     background: {
         default: neutrals[50],
     },
+    action: {
+        active: neutrals[400],
+        disabled: neutrals[200],
+    },
 };

--- a/packages/admin/src/common/buttons/clearinput/ClearInputButton.tsx
+++ b/packages/admin/src/common/buttons/clearinput/ClearInputButton.tsx
@@ -1,28 +1,32 @@
 import { Clear } from "@comet/admin-icons";
 import { ButtonBase, ButtonBaseClassKey, ButtonBaseProps, WithStyles } from "@material-ui/core";
+import { Theme } from "@material-ui/core/styles";
 import { createStyles, withStyles } from "@material-ui/styles";
 import * as React from "react";
 
 export type ClearInputButtonClassKey = ButtonBaseClassKey;
 export interface ClearInputButtonProps extends ButtonBaseProps {
-    icon?: (disabled?: boolean) => React.ReactNode;
+    icon?: React.ReactNode;
 }
 
-const styles = () => {
+const styles = ({ palette }: Theme) => {
     return createStyles<ClearInputButtonClassKey, ClearInputButtonProps>({
         root: {
             height: "100%",
             width: 40,
+            color: palette.action.active,
         },
-        disabled: {},
+        disabled: {
+            color: palette.action.disabled,
+        },
         focusVisible: {},
     });
 };
 
-const ClearInputBtn: React.FC<WithStyles<typeof styles> & ClearInputButtonProps> = ({ icon, disabled, ...restProps }) => {
+const ClearInputBtn: React.FC<WithStyles<typeof styles> & ClearInputButtonProps> = ({ icon = <Clear />, ...restProps }) => {
     return (
-        <ButtonBase tabIndex={-1} disabled={disabled} {...restProps}>
-            {icon ? icon(disabled) : <Clear color={disabled ? "disabled" : "action"} />}
+        <ButtonBase tabIndex={-1} {...restProps}>
+            {icon}
         </ButtonBase>
     );
 };


### PR DESCRIPTION
MuiSvgIcon uses "color: inherit" by default and therefore the color can be set in the ButtonBase root and a disabled-prop is no longer needed for the icon.