### PR TITLE
Import storybook-docs correctly

### DIFF
--- a/packages/admin-stories/src/docs/Intro.stories.mdx
+++ b/packages/admin-stories/src/docs/Intro.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Intro" />
 

--- a/packages/admin-stories/src/docs/PrettyBytes/PrettyBytes.stories.mdx
+++ b/packages/admin-stories/src/docs/PrettyBytes/PrettyBytes.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { PrettyBytes } from "@comet/admin";
 
 # PrettyBytes

--- a/packages/admin-stories/src/docs/bestPractices/Overview.stories.mdx
+++ b/packages/admin-stories/src/docs/bestPractices/Overview.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Best Practices/Overview" />
 

--- a/packages/admin-stories/src/docs/bestPractices/ThemeAndStyling.stories.mdx
+++ b/packages/admin-stories/src/docs/bestPractices/ThemeAndStyling.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Best Practices/Theme and Styling" />
 

--- a/packages/admin-stories/src/docs/components/AppHeader/AppHeader.stories.mdx
+++ b/packages/admin-stories/src/docs/components/AppHeader/AppHeader.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Story } from "@storybook/addon-docs/blocks";
+import { Meta, Canvas, Story } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/AppHeader" />
 

--- a/packages/admin-stories/src/docs/components/ClearInputButton/ClearInputButton.stories.mdx
+++ b/packages/admin-stories/src/docs/components/ClearInputButton/ClearInputButton.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/ClearInputButton" />
 

--- a/packages/admin-stories/src/docs/components/ColorPicker/ColorPicker.stories.mdx
+++ b/packages/admin-stories/src/docs/components/ColorPicker/ColorPicker.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Story } from "@storybook/addon-docs/blocks";
+import { Meta, Canvas, Story } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/Color Picker" />
 

--- a/packages/admin-stories/src/docs/components/DatePicker.stories.mdx
+++ b/packages/admin-stories/src/docs/components/DatePicker.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/Date Picker" />
 

--- a/packages/admin-stories/src/docs/components/EditDialog.stories.mdx
+++ b/packages/admin-stories/src/docs/components/EditDialog.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/Edit Dialog" />
 

--- a/packages/admin-stories/src/docs/components/ErrorHandling/ErrorBoundaries.stories.mdx
+++ b/packages/admin-stories/src/docs/components/ErrorHandling/ErrorBoundaries.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/Error Handling/ErrorBoundaries" />
 

--- a/packages/admin-stories/src/docs/components/ErrorHandling/ErrorDialog/ErrorDialog.stories.mdx
+++ b/packages/admin-stories/src/docs/components/ErrorHandling/ErrorDialog/ErrorDialog.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Story } from "@storybook/addon-docs/blocks";
+import { Meta, Canvas, Story } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/Error Handling/Error Dialog" />
 

--- a/packages/admin-stories/src/docs/components/FinalFormRangeInput/FinalFormRangeInput.stories.mdx
+++ b/packages/admin-stories/src/docs/components/FinalFormRangeInput/FinalFormRangeInput.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/FinalFormRangeInput" />
 

--- a/packages/admin-stories/src/docs/components/Master/Master.stories.mdx
+++ b/packages/admin-stories/src/docs/components/Master/Master.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Story } from "@storybook/addon-docs/blocks";
+import { Meta, Canvas, Story } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/Master" />
 

--- a/packages/admin-stories/src/docs/components/Menu.stories.mdx
+++ b/packages/admin-stories/src/docs/components/Menu.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/Menu" />
 

--- a/packages/admin-stories/src/docs/components/ReactSelect.stories.mdx
+++ b/packages/admin-stories/src/docs/components/ReactSelect.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/React Select" />
 

--- a/packages/admin-stories/src/docs/components/Router.stories.mdx
+++ b/packages/admin-stories/src/docs/components/Router.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/Router" />
 

--- a/packages/admin-stories/src/docs/components/RouterTabs.stories.mdx
+++ b/packages/admin-stories/src/docs/components/RouterTabs.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/Router Tabs" />
 

--- a/packages/admin-stories/src/docs/components/Rte.stories.mdx
+++ b/packages/admin-stories/src/docs/components/Rte.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/Rte" />
 

--- a/packages/admin-stories/src/docs/components/SaveButton/SaveButton.stories.mdx
+++ b/packages/admin-stories/src/docs/components/SaveButton/SaveButton.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/SaveButton" />
 

--- a/packages/admin-stories/src/docs/components/Selection.stories.mdx
+++ b/packages/admin-stories/src/docs/components/Selection.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/Selection" />
 

--- a/packages/admin-stories/src/docs/components/Snackbar/Snackbar.stories.mdx
+++ b/packages/admin-stories/src/docs/components/Snackbar/Snackbar.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Source } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas, Source } from "@storybook/addon-docs";
 
 import dedent from "ts-dedent";
 

--- a/packages/admin-stories/src/docs/components/SplitButton/SplitButton.stories.mdx
+++ b/packages/admin-stories/src/docs/components/SplitButton/SplitButton.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/SplitButton" />
 

--- a/packages/admin-stories/src/docs/components/Stack/Stack.stories.mdx
+++ b/packages/admin-stories/src/docs/components/Stack/Stack.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Story, Source } from "@storybook/addon-docs/blocks";
+import { Meta, Canvas, Story, Source } from "@storybook/addon-docs";
 
 import dedent from "ts-dedent";
 

--- a/packages/admin-stories/src/docs/components/Table.stories.mdx
+++ b/packages/admin-stories/src/docs/components/Table.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/Table" />
 

--- a/packages/admin-stories/src/docs/components/TableForm.stories.mdx
+++ b/packages/admin-stories/src/docs/components/TableForm.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/Table Form" />
 

--- a/packages/admin-stories/src/docs/components/Toolbar/Toolbar.stories.mdx
+++ b/packages/admin-stories/src/docs/components/Toolbar/Toolbar.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
 <Meta title="Docs/Components/Toolbar" />
 

--- a/packages/admin-stories/src/docs/development/CreateAComponentWithThemeSupport.stories.mdx
+++ b/packages/admin-stories/src/docs/development/CreateAComponentWithThemeSupport.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Development/Create a component with theme support" />
 

--- a/packages/admin-stories/src/docs/development/Overview.stories.mdx
+++ b/packages/admin-stories/src/docs/development/Overview.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Development/Overview" />
 

--- a/packages/admin-stories/src/docs/form/Overview.stories.mdx
+++ b/packages/admin-stories/src/docs/form/Overview.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
 <Meta title="Docs/Form/Overview" />
 

--- a/packages/admin-stories/src/docs/form/Validation.stories.mdx
+++ b/packages/admin-stories/src/docs/form/Validation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
 <Meta title="Docs/Form/Validation" />
 

--- a/packages/admin-stories/src/docs/form/components/Field.stories.mdx
+++ b/packages/admin-stories/src/docs/form/components/Field.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
 <Meta title="Docs/Form/Components/Field" />
 

--- a/packages/admin-stories/src/docs/form/components/FieldContainer.stories.mdx
+++ b/packages/admin-stories/src/docs/form/components/FieldContainer.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
 <Meta title="Docs/Form/Components/FieldContainer" />
 

--- a/packages/admin-stories/src/docs/form/components/FormSection.stories.mdx
+++ b/packages/admin-stories/src/docs/form/components/FormSection.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
 <Meta title="Docs/Form/Components/FormSection" />
 

--- a/packages/admin-stories/src/docs/gettingstarted/DevelopInProject.stories.mdx
+++ b/packages/admin-stories/src/docs/gettingstarted/DevelopInProject.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Getting Started/Develop in project" />
 

--- a/packages/admin-stories/src/docs/gettingstarted/HowToWriteStories.stories.mdx
+++ b/packages/admin-stories/src/docs/gettingstarted/HowToWriteStories.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Getting Started/How to write stories" />
 

--- a/packages/admin-stories/src/docs/gettingstarted/Installation.stories.mdx
+++ b/packages/admin-stories/src/docs/gettingstarted/Installation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Getting Started/Installation" />
 

--- a/packages/admin-stories/src/docs/gettingstarted/Structure.stories.mdx
+++ b/packages/admin-stories/src/docs/gettingstarted/Structure.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Getting Started/Structure" />
 

--- a/packages/admin-stories/src/docs/hooks/Hooks.stories.mdx
+++ b/packages/admin-stories/src/docs/hooks/Hooks.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Hooks/Hooks" />
 

--- a/packages/admin-stories/src/docs/hooks/useStoredState/useStoredState.stories.mdx
+++ b/packages/admin-stories/src/docs/hooks/useStoredState/useStoredState.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
 <Meta title="Docs/Hooks/useStoredState" />
 

--- a/packages/admin-stories/src/docs/hooks/useWindowSize.stories.mdx
+++ b/packages/admin-stories/src/docs/hooks/useWindowSize.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs";
 
 <Meta title="Docs/Hooks/useWindowSize" />
 

--- a/packages/admin-stories/src/docs/icons/IconList.stories.mdx
+++ b/packages/admin-stories/src/docs/icons/IconList.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Story } from "@storybook/addon-docs/blocks";
+import { Meta, Canvas, Story } from "@storybook/addon-docs";
 
 <Meta title="Docs/Icons/List" />
 

--- a/packages/admin-stories/src/docs/icons/IconsUsage.stories.mdx
+++ b/packages/admin-stories/src/docs/icons/IconsUsage.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Story } from "@storybook/addon-docs/blocks";
+import { Meta, Canvas, Story } from "@storybook/addon-docs";
 
 <Meta title="Docs/Icons/Usage" />
 


### PR DESCRIPTION
Fixes message "Importing from '@storybook/addon-docs/blocks' is deprecated,
import directly from '@storybook/addon-docs' instead"