### PR TITLE
Fix DirtyHandler-Prompt popping up when submitting EditDialog-Form

### DIFF
--- a/packages/admin-stories/src/admin/table/TableEditDialog.tsx
+++ b/packages/admin-stories/src/admin/table/TableEditDialog.tsx
@@ -20,38 +20,38 @@ import * as React from "react";
 import { apolloStoryDecorator } from "../../apollo-story.decorator";
 import { storyRouterDecorator } from "../../story-router.decorator";
 
-interface IExampleRow {
-    id: number;
-    foo: string;
-    bar: string;
-}
-
-interface IEditFormProps {
-    row: IExampleRow;
-    mode: "edit" | "add";
-}
-function EditForm(props: IEditFormProps) {
-    return (
-        <FinalForm
-            mode={props.mode}
-            initialValues={props.row}
-            onSubmit={(values) => {
-                alert(JSON.stringify(values));
-            }}
-        >
-            <Field name="foo" component={FinalFormInput} type="text" label="Name" fullWidth />
-        </FinalForm>
-    );
-}
-
 function Story() {
-    const data: IExampleRow[] = [
+    interface IEditFormProps {
+        row: IExampleRow;
+        mode: "edit" | "add";
+    }
+    function EditForm(props: IEditFormProps) {
+        return (
+            <FinalForm
+                mode={props.mode}
+                initialValues={props.row}
+                onSubmit={async (values: IExampleRow) => {
+                    await new Promise((resolve) => setTimeout(resolve, 500));
+                    const index = data.findIndex((d) => d.id === values.id);
+                    data[index] = values;
+                    setData([...data]);
+                }}
+            >
+                <Field name="foo" component={FinalFormInput} type="text" label="Name" fullWidth />
+            </FinalForm>
+        );
+    }
+
+    interface IExampleRow {
+        id: number;
+        foo: string;
+        bar: string;
+    }
+    const [data, setData] = React.useState<IExampleRow[]>([
         { id: 1, foo: "blub", bar: "blub" },
         { id: 2, foo: "blub", bar: "blub" },
-    ];
-
+    ]);
     const editDialog = React.useRef<IEditDialogApi>(null);
-
     return (
         <>
             <Toolbar>

--- a/packages/admin-stories/src/admin/table/TableEditDialogHooks.tsx
+++ b/packages/admin-stories/src/admin/table/TableEditDialogHooks.tsx
@@ -19,35 +19,37 @@ import * as React from "react";
 import { apolloStoryDecorator } from "../../apollo-story.decorator";
 import { storyRouterDecorator } from "../../story-router.decorator";
 
-interface IExampleRow {
-    id: number;
-    foo: string;
-    bar: string;
-}
-
-interface IEditFormProps {
-    row: IExampleRow;
-    mode: "edit" | "add";
-}
-function EditForm(props: IEditFormProps) {
-    return (
-        <FinalForm
-            mode={props.mode}
-            initialValues={props.row}
-            onSubmit={(values) => {
-                alert(JSON.stringify(values));
-            }}
-        >
-            <Field name="foo" component={FinalFormInput} type="text" label="Name" fullWidth />
-        </FinalForm>
-    );
-}
-
 function Story() {
-    const data: IExampleRow[] = [
+    interface IEditFormProps {
+        row: IExampleRow;
+        mode: "edit" | "add";
+    }
+    function EditForm(props: IEditFormProps) {
+        return (
+            <FinalForm
+                mode={props.mode}
+                initialValues={props.row}
+                onSubmit={async (values: IExampleRow) => {
+                    await new Promise((resolve) => setTimeout(resolve, 500));
+                    const index = data.findIndex((d) => d.id === values.id);
+                    data[index] = values;
+                    setData([...data]);
+                }}
+            >
+                <Field name="foo" component={FinalFormInput} type="text" label="Name" fullWidth />
+            </FinalForm>
+        );
+    }
+
+    interface IExampleRow {
+        id: number;
+        foo: string;
+        bar: string;
+    }
+    const [data, setData] = React.useState<IExampleRow[]>([
         { id: 1, foo: "blub", bar: "blub" },
         { id: 2, foo: "blub", bar: "blub" },
-    ];
+    ]);
 
     const [EditDialog, selection, api] = useEditDialog();
 

--- a/packages/admin/src/EditDialog.tsx
+++ b/packages/admin/src/EditDialog.tsx
@@ -94,6 +94,7 @@ const EditDialogInner: React.FunctionComponent<IProps & IHookProps> = ({ selecti
 
                 if (!failed) {
                     setTimeout(() => {
+                        if (dirtyHandlerApi) dirtyHandlerApi.resetBindings();
                         selectionApi.handleDeselect();
                     });
                 }


### PR DESCRIPTION
After clicking Save in EditDialog (beneath a DirtyHandler) this happens:
- EditDialog calls DirtyHandler.submitBindings()
- DirtyHandler calls FinalForm.submit() to get submit errors
- So that EditDialog can call SelectionApi.handleDeselect()
- SelectionApi changes Url
- react-router reacts to updated Url and tries to render Prompt
- Prompt calls DirtyHandler.promptMessage()
- DirtyHandler calls FinalForm.isDirty()
- And here is the problem, this returns true because the form was not resetted
- So that promptMessage return a string and the Prompt is shown

The fix is to reset the form after a successful submit.