### PR TITLE
Handle Prompt-Actions in DirtyHandler first

### DIFF
--- a/packages/admin/src/EditDialog.tsx
+++ b/packages/admin/src/EditDialog.tsx
@@ -107,10 +107,14 @@ const EditDialogInner: React.FunctionComponent<IProps & IHookProps> = ({ selecti
         selectionApi.handleDeselect();
     };
 
+    const handleCloseClick = () => {
+        selectionApi.handleDeselect();
+    };
+
     return (
         <EditDialogApiContext.Provider value={api}>
             <DirtyHandler>
-                <Dialog open={!!selection.mode} onClose={handleCancelClick}>
+                <Dialog open={!!selection.mode} onClose={handleCloseClick}>
                     <div>
                         <DialogTitle>{typeof title === "string" ? title : selection.mode === "edit" ? title.edit : title.add}</DialogTitle>
                         <DialogContent>{children}</DialogContent>

--- a/packages/admin/src/router/BrowserRouter.tsx
+++ b/packages/admin/src/router/BrowserRouter.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
 import { BrowserRouter as ReactBrowserRouter, BrowserRouterProps } from "react-router-dom";
 
-import { RouterConfirmationDialog } from "./ConfirmationDialog";
-import { RouterPromptHandler } from "./PromptHandler";
+import { AllowTransition, RouterPromptHandler } from "./PromptHandler";
 
 // BrowserRouter that sets up a material-ui confirmation dialog
 // plus a PromptHandler that works with our Prompt (supporting multiple Prompts)
@@ -26,7 +25,7 @@ export const RouterBrowserRouter: React.FunctionComponent<BrowserRouterProps> = 
             callback,
         });
     };
-    const handleClose = (allowTransition: boolean) => {
+    const handleClose = (allowTransition: AllowTransition) => {
         if (state.callback) {
             state.callback(allowTransition);
         }
@@ -39,9 +38,8 @@ export const RouterBrowserRouter: React.FunctionComponent<BrowserRouterProps> = 
 
     return (
         <ReactBrowserRouter getUserConfirmation={getConfirmation} {...props}>
-            <RouterPromptHandler>
+            <RouterPromptHandler showDialog={state.showConfirmationDialog} dialogMessage={state.message} handleDialogClose={handleClose}>
                 {children}
-                <RouterConfirmationDialog isOpen={state.showConfirmationDialog} message={state.message} handleClose={handleClose} />
             </RouterPromptHandler>
         </ReactBrowserRouter>
     );

--- a/packages/admin/src/router/ConfirmationDialog.tsx
+++ b/packages/admin/src/router/ConfirmationDialog.tsx
@@ -1,22 +1,39 @@
-import { Dialog, DialogActions, DialogTitle } from "@material-ui/core";
+import { Delete, Save } from "@comet/admin-icons";
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from "@material-ui/core";
 import * as React from "react";
+import { FormattedMessage } from "react-intl";
 
+import { ToolbarFillSpace } from "..";
 import { CancelButton } from "../common/buttons/cancel/CancelButton";
-import { OkayButton } from "../common/buttons/okay/OkayButton";
+
+export enum PromptAction {
+    Cancel,
+    Discard,
+    Save,
+}
 
 interface Props {
     isOpen: boolean;
     message: React.ReactNode; // typically a string or a FormattedMessage (intl) is passed
-    handleClose: (ok: boolean) => void;
+    handleClose: (action: PromptAction) => void;
 }
 
 export function RouterConfirmationDialog({ message, handleClose, isOpen }: Props) {
     return (
-        <Dialog open={isOpen} onClose={handleClose.bind(this, false)} maxWidth={"xs"}>
-            <DialogTitle>{message}</DialogTitle>
+        <Dialog open={isOpen} onClose={() => handleClose(PromptAction.Cancel)} maxWidth="sm">
+            <DialogTitle>
+                <FormattedMessage id="cometAdmin.generic.unsavedChanges" defaultMessage="Unsaved Changes" />
+            </DialogTitle>
+            <DialogContent>{message}</DialogContent>
             <DialogActions>
-                <CancelButton onClick={handleClose.bind(this, false)} />
-                <OkayButton onClick={handleClose.bind(this, true)} autoFocus />
+                <CancelButton onClick={() => handleClose(PromptAction.Cancel)} />
+                <ToolbarFillSpace />
+                <Button startIcon={<Delete />} color="default" variant="contained" onClick={() => handleClose(PromptAction.Discard)}>
+                    <FormattedMessage id="cometAdmin.generic.discard" defaultMessage="Discard" />
+                </Button>
+                <Button startIcon={<Save />} color="primary" variant="contained" onClick={() => handleClose(PromptAction.Save)}>
+                    <FormattedMessage id="cometAdmin.generic.save" defaultMessage="Save" />
+                </Button>
             </DialogActions>
         </Dialog>
     );

--- a/packages/admin/src/router/Context.tsx
+++ b/packages/admin/src/router/Context.tsx
@@ -1,8 +1,14 @@
 import * as History from "history";
 import * as React from "react";
 
+import { PromptActionCallback } from "./PromptHandler";
+
 interface IContext {
-    register: (id: string, message: (location: History.Location, action: History.Action) => string | boolean) => void;
+    register: (
+        id: string,
+        message: (location: History.Location, action: History.Action) => string | boolean,
+        handlePromptAction: PromptActionCallback,
+    ) => void;
     unregister: (id: string) => void;
 }
 

--- a/packages/admin/src/router/MemoryRouter.tsx
+++ b/packages/admin/src/router/MemoryRouter.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { MemoryRouter as ReactMemoryRouter, MemoryRouterProps } from "react-router-dom";
 
-import { RouterConfirmationDialog } from "./ConfirmationDialog";
 import { RouterPromptHandler } from "./PromptHandler";
 
 // MemoryRouter that sets up a material-ui confirmation dialog
@@ -39,9 +38,8 @@ export const RouterMemoryRouter: React.FunctionComponent<MemoryRouterProps> = ({
 
     return (
         <ReactMemoryRouter getUserConfirmation={getConfirmation} {...props}>
-            <RouterPromptHandler>
+            <RouterPromptHandler showDialog={state.showConfirmationDialog} dialogMessage={state.message} handleDialogClose={handleClose}>
                 {children}
-                <RouterConfirmationDialog isOpen={state.showConfirmationDialog} message={state.message} handleClose={handleClose} />
             </RouterPromptHandler>
         </ReactMemoryRouter>
     );

--- a/packages/admin/src/router/Prompt.tsx
+++ b/packages/admin/src/router/Prompt.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import useConstant from "use-constant";
 
 import { RouterContext } from "./Context";
+import { PromptActionCallback } from "./PromptHandler";
 const UUID = require("uuid");
 
 // react-router Prompt doesn't support multiple Prompts, this one does
@@ -12,13 +13,14 @@ interface IProps {
      * Return a string to show a prompt to the user or true to allow the transition.
      */
     message: (location: History.Location, action: History.Action) => boolean | string;
+    handlePromptAction: PromptActionCallback;
 }
-export const RouterPrompt: React.FunctionComponent<IProps> = ({ message }) => {
+export const RouterPrompt: React.FunctionComponent<IProps> = ({ message, handlePromptAction }) => {
     const id = useConstant<string>(() => UUID.v4());
     const context = React.useContext(RouterContext);
     React.useEffect(() => {
         if (context) {
-            context.register(id, message);
+            context.register(id, message, handlePromptAction);
         }
         return function cleanup() {
             if (context) {

--- a/packages/admin/src/router/PromptHandler.tsx
+++ b/packages/admin/src/router/PromptHandler.tsx
@@ -2,17 +2,32 @@ import * as History from "history";
 import * as React from "react";
 import { Prompt } from "react-router";
 
+import { PromptAction, RouterConfirmationDialog } from "./ConfirmationDialog";
 import { RouterContext } from "./Context";
 
 interface IMessages {
     [id: string]: (location: History.Location, action: History.Action) => boolean | string;
 }
+interface Props {
+    showDialog: boolean;
+    dialogMessage: string;
+    handleDialogClose: (ok: boolean) => void;
+}
 
-export const RouterPromptHandler: React.FunctionComponent<{}> = ({ children, ...props }) => {
+export type AllowTransition = boolean;
+export type PromptActionCallback = (action: PromptAction) => Promise<AllowTransition>;
+
+export const RouterPromptHandler: React.FunctionComponent<Props> = ({ children, showDialog, dialogMessage, handleDialogClose }) => {
     const registeredMessages = React.useRef<IMessages>({});
+    const promptActions: PromptActionCallback[] = [];
 
-    const register = (id: string, message: (location: History.Location, action: History.Action) => string | boolean) => {
+    const register = (
+        id: string,
+        message: (location: History.Location, action: History.Action) => string | boolean,
+        handlePromptAction: PromptActionCallback,
+    ) => {
         registeredMessages.current[id] = message;
+        promptActions.push(handlePromptAction);
     };
 
     const unregister = (id: string) => {
@@ -31,6 +46,11 @@ export const RouterPromptHandler: React.FunctionComponent<{}> = ({ children, ...
         return ret;
     };
 
+    const handleClose = async (action: PromptAction) => {
+        const results: Array<AllowTransition> = await Promise.all(promptActions.map(async (promptAction) => await promptAction(action)));
+        handleDialogClose(results.every((result) => result));
+    };
+
     return (
         <RouterContext.Provider
             value={{
@@ -38,6 +58,7 @@ export const RouterPromptHandler: React.FunctionComponent<{}> = ({ children, ...
                 unregister,
             }}
         >
+            <RouterConfirmationDialog isOpen={showDialog} message={dialogMessage} handleClose={handleClose} />
             <Prompt when={true} message={promptMessage} />
             {children}
         </RouterContext.Provider>

--- a/packages/admin/src/router/PromptHandler.tsx
+++ b/packages/admin/src/router/PromptHandler.tsx
@@ -47,7 +47,7 @@ export const RouterPromptHandler: React.FunctionComponent<Props> = ({ children, 
     };
 
     const handleClose = async (action: PromptAction) => {
-        const results: Array<AllowTransition> = await Promise.all(promptActions.map(async (promptAction) => await promptAction(action)));
+        const results: Array<AllowTransition> = await Promise.all(promptActions.map((promptAction) => promptAction(action)));
         handleDialogClose(results.every((result) => result));
     };
 


### PR DESCRIPTION
Now three options (Cancel, Discard, Save) exist in Prompt (Dialog
which will be shown when user wants to navigate away from a page
with a Dirty state). To handle the user action DirtyHandler registers
a callback into the RouterContext. The result of this callback
(allowTransition) is used for the react-router callback.

https://user-images.githubusercontent.com/1013756/142436607-b6cad01c-57c1-413a-bc7a-2f517800aef2.mp4
