### PR TITLE
Fix table filter debouncing for non-text fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6341,6 +6341,15 @@
             "integrity": "sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg==",
             "dev": true
         },
+        "node_modules/@types/lodash.debounce": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz",
+            "integrity": "sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/lodash": "*"
+            }
+        },
         "node_modules/@types/lodash.isequal": {
             "version": "4.5.5",
             "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.5.tgz",
@@ -11024,11 +11033,6 @@
             "version": "1.10.6",
             "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.6.tgz",
             "integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw=="
-        },
-        "node_modules/debounce": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
-            "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
         },
         "node_modules/debug": {
             "version": "4.3.2",
@@ -27948,8 +27952,8 @@
                 "@comet/admin-icons": "^2.0.0",
                 "@material-ui/lab": "^4.0.0-alpha.57",
                 "clsx": "^1.1.1",
-                "debounce": "^1.2.0",
                 "final-form-set-field-data": "^1.0.2",
+                "lodash.debounce": "^4.0.8",
                 "lodash.isequal": "^4.5.0",
                 "query-string": "^6.8.1",
                 "use-constant": "^1.0.0",
@@ -27959,6 +27963,7 @@
                 "@types/debounce": "^1.2.0",
                 "@types/file-saver": "^2.0.1",
                 "@types/final-form-set-field-data": "^1.0.0",
+                "@types/lodash.debounce": "^4.0.6",
                 "@types/lodash.isequal": "^4.5.5",
                 "@types/react-dom": "^16.9.11",
                 "@types/react-router": "^5.1.12",
@@ -31360,15 +31365,16 @@
                 "@types/debounce": "^1.2.0",
                 "@types/file-saver": "^2.0.1",
                 "@types/final-form-set-field-data": "^1.0.0",
+                "@types/lodash.debounce": "^4.0.6",
                 "@types/lodash.isequal": "^4.5.5",
                 "@types/react-dom": "^16.9.11",
                 "@types/react-router": "^5.1.12",
                 "@types/react-router-dom": "^5.1.7",
                 "@types/styled-components": "^5.1.7",
                 "clsx": "^1.1.1",
-                "debounce": "^1.2.0",
                 "final-form-set-field-data": "^1.0.2",
                 "jss": "^10.6.0",
+                "lodash.debounce": "^4.0.8",
                 "lodash.isequal": "^4.5.0",
                 "query-string": "^6.8.1",
                 "use-constant": "^1.0.0",
@@ -35122,6 +35128,15 @@
             "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.171.tgz",
             "integrity": "sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg==",
             "dev": true
+        },
+        "@types/lodash.debounce": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz",
+            "integrity": "sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==",
+            "dev": true,
+            "requires": {
+                "@types/lodash": "*"
+            }
         },
         "@types/lodash.isequal": {
             "version": "4.5.5",
@@ -40212,11 +40227,6 @@
             "version": "1.10.6",
             "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.6.tgz",
             "integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw=="
-        },
-        "debounce": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
-            "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
         },
         "debug": {
             "version": "4.3.2",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -12,20 +12,21 @@
         "directory": "packages/admin"
     },
     "dependencies": {
-        "@material-ui/lab": "^4.0.0-alpha.57",
         "@comet/admin-icons": "^2.0.0",
-        "debounce": "^1.2.0",
+        "@material-ui/lab": "^4.0.0-alpha.57",
+        "clsx": "^1.1.1",
         "final-form-set-field-data": "^1.0.2",
+        "lodash.debounce": "^4.0.8",
         "lodash.isequal": "^4.5.0",
         "query-string": "^6.8.1",
         "use-constant": "^1.0.0",
-        "uuid": "^3.3.2",
-        "clsx": "^1.1.1"
+        "uuid": "^3.3.2"
     },
     "devDependencies": {
         "@types/debounce": "^1.2.0",
         "@types/file-saver": "^2.0.1",
         "@types/final-form-set-field-data": "^1.0.0",
+        "@types/lodash.debounce": "^4.0.6",
         "@types/lodash.isequal": "^4.5.5",
         "@types/react-dom": "^16.9.11",
         "@types/react-router": "^5.1.12",
@@ -44,9 +45,9 @@
         "graphql": "^14.0.0 || ^15.0.0",
         "history": "^4.10.1",
         "react": "^16.8 || ^17.0",
+        "react-dnd": "^14.0.2",
         "react-dom": "^16.8 || ^17.0",
         "react-final-form": "^6.3.1",
-        "react-dnd": "^14.0.2",
         "react-intl": "^5.10.0",
         "react-router": "^5.1.2",
         "react-router-dom": "^5.1.2",

--- a/packages/admin/src/table/useTableQueryFilter.tsx
+++ b/packages/admin/src/table/useTableQueryFilter.tsx
@@ -1,6 +1,6 @@
-import { debounce } from "debounce";
 import { AnyObject, createForm, FormApi } from "final-form";
-import isEqual = require("lodash.isequal");
+import debounce from "lodash.debounce";
+import isEqual from "lodash.isequal";
 import * as React from "react";
 
 import { usePersistedState } from "./usePersistedState";
@@ -33,15 +33,19 @@ export function useTableQueryFilter<FilterValues>(
     React.useEffect(() => {
         if (!ref.current) return;
         const unsubscribe = ref.current.subscribe(
-            debounce((formState) => {
-                const newValues = formState.values;
-                if (!isEqual(filters, newValues)) {
-                    setFilters(newValues);
-                    if (options.pagingApi) {
-                        options.pagingApi.changePage(options.pagingApi.init, 1, { noScrollToTop: true });
+            debounce(
+                (formState) => {
+                    const newValues = formState.values;
+                    if (!isEqual(filters, newValues)) {
+                        setFilters(newValues);
+                        if (options.pagingApi) {
+                            options.pagingApi.changePage(options.pagingApi.init, 1, { noScrollToTop: true });
+                        }
                     }
-                }
-            }, 500),
+                },
+                500,
+                { leading: true, trailing: true },
+            ),
             { values: true },
         );
         return unsubscribe;


### PR DESCRIPTION
Previously, non-text fields such as selects would wait 500ms before submitting the new filter value. This was due to the debounce function submitting only on the `trailing` edge. This change resolves the issue by submitting new filter values on both the `leading` and the `trailing` edge (see [lodash.debounce documentation](https://lodash.com/docs/#debounce) for more information).

# Demo

## Non-text field

https://user-images.githubusercontent.com/48853629/144025303-5137882d-0c16-46cc-9952-5580eb54d643.mov

## Text field

https://user-images.githubusercontent.com/48853629/144025347-3f7193f0-4aad-48f6-92e5-e068849e3188.mov

# Concerns

The new behavior immediately submits the first input of a text field. I've not noticed an impact to the user experience in my testing (see demo above). However, the new behavior might cause additional (somewhat useless) API requests. 

If we want to prevent immediate submission for text fields, we need to check which form field has changed and determine whether it is a text field or not. We may use the `type` prop of the field for this, but I doubt that we are using this prop consistently. Determining the field type based on the field value alone is not feasible, because the value of a select might be a string. 


