### PR TITLE
Simplify prompt actions

### DIFF
--- a/packages/admin/src/DirtyHandler.tsx
+++ b/packages/admin/src/DirtyHandler.tsx
@@ -3,9 +3,7 @@ import { defineMessages, useIntl, WrappedComponentProps } from "react-intl";
 
 import { DirtyHandlerApiContext, IDirtyHandlerApi, IDirtyHandlerApiBinding } from "./DirtyHandlerApiContext";
 import { SubmitResult } from "./form/SubmitResult";
-import { PromptAction } from "./router/ConfirmationDialog";
 import { RouterPrompt } from "./router/Prompt";
-import { AllowTransition } from "./router/PromptHandler";
 
 interface IProps {
     children?: React.ReactNode;
@@ -70,20 +68,15 @@ class DirtyHandlerComponent extends React.Component<IProps & WrappedComponentPro
     public render() {
         return (
             <DirtyHandlerApiContext.Provider value={this.dirtyHandlerApi}>
-                <RouterPrompt message={this.promptMessage} handlePromptAction={this.handlePromptAction} />
+                <RouterPrompt message={this.promptMessage} saveAction={this.saveAction} />
                 {this.props.children}
             </DirtyHandlerApiContext.Provider>
         );
     }
 
-    private handlePromptAction = async (action: PromptAction): Promise<AllowTransition> => {
-        if (action === PromptAction.Discard) {
-            return true;
-        } else if (action === PromptAction.Save) {
-            const submitResults: Array<SubmitResult> = await this.submitBindings();
-            return submitResults.every((submitResult) => !submitResult.error);
-        }
-        return false;
+    private saveAction = async (): Promise<boolean> => {
+        const submitResults: Array<SubmitResult> = await this.submitBindings();
+        return submitResults.every((submitResult) => !submitResult.error);
     };
 
     private promptMessage = (): string | boolean => {

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -1,10 +1,10 @@
 export { IWindowSize, useWindowSize } from "./helpers/useWindowSize";
 export { RouterBrowserRouter } from "./router/BrowserRouter";
 export { RouterMemoryRouter } from "./router/MemoryRouter";
-export { RouterConfirmationDialog, PromptAction } from "./router/ConfirmationDialog";
+export { RouterConfirmationDialog } from "./router/ConfirmationDialog";
 export { RouterContext } from "./router/Context";
 export { RouterPrompt } from "./router/Prompt";
-export { RouterPromptHandler, PromptActionCallback } from "./router/PromptHandler";
+export { RouterPromptHandler, SaveAction } from "./router/PromptHandler";
 export { IStackApi, IWithApiProps, StackApiContext, useStackApi, withStackApi } from "./stack/Api";
 export { StackBreadcrumb } from "./stack/Breadcrumb";
 export { IStackPageProps, StackPage } from "./stack/Page";

--- a/packages/admin/src/router/BrowserRouter.tsx
+++ b/packages/admin/src/router/BrowserRouter.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { BrowserRouter as ReactBrowserRouter, BrowserRouterProps } from "react-router-dom";
 
-import { AllowTransition, RouterPromptHandler } from "./PromptHandler";
+import { RouterPromptHandler } from "./PromptHandler";
 
 // BrowserRouter that sets up a material-ui confirmation dialog
 // plus a PromptHandler that works with our Prompt (supporting multiple Prompts)
@@ -25,7 +25,7 @@ export const RouterBrowserRouter: React.FunctionComponent<BrowserRouterProps> = 
             callback,
         });
     };
-    const handleClose = (allowTransition: AllowTransition) => {
+    const handleClose = (allowTransition: boolean) => {
         if (state.callback) {
             state.callback(allowTransition);
         }

--- a/packages/admin/src/router/ConfirmationDialog.tsx
+++ b/packages/admin/src/router/ConfirmationDialog.tsx
@@ -16,9 +16,10 @@ interface Props {
     isOpen: boolean;
     message: React.ReactNode; // typically a string or a FormattedMessage (intl) is passed
     handleClose: (action: PromptAction) => void;
+    showSaveButton: boolean;
 }
 
-export function RouterConfirmationDialog({ message, handleClose, isOpen }: Props) {
+export function RouterConfirmationDialog({ message, handleClose, isOpen, showSaveButton = false }: Props) {
     return (
         <Dialog open={isOpen} onClose={() => handleClose(PromptAction.Cancel)} maxWidth="sm">
             <DialogTitle>
@@ -31,9 +32,11 @@ export function RouterConfirmationDialog({ message, handleClose, isOpen }: Props
                 <Button startIcon={<Delete />} color="default" variant="contained" onClick={() => handleClose(PromptAction.Discard)}>
                     <FormattedMessage id="cometAdmin.generic.discard" defaultMessage="Discard" />
                 </Button>
-                <Button startIcon={<Save />} color="primary" variant="contained" onClick={() => handleClose(PromptAction.Save)}>
-                    <FormattedMessage id="cometAdmin.generic.save" defaultMessage="Save" />
-                </Button>
+                {showSaveButton && (
+                    <Button startIcon={<Save />} color="primary" variant="contained" onClick={() => handleClose(PromptAction.Save)}>
+                        <FormattedMessage id="cometAdmin.generic.save" defaultMessage="Save" />
+                    </Button>
+                )}
             </DialogActions>
         </Dialog>
     );

--- a/packages/admin/src/router/Context.tsx
+++ b/packages/admin/src/router/Context.tsx
@@ -1,14 +1,10 @@
 import * as History from "history";
 import * as React from "react";
 
-import { PromptActionCallback } from "./PromptHandler";
+import { SaveAction } from "./PromptHandler";
 
 interface IContext {
-    register: (
-        id: string,
-        message: (location: History.Location, action: History.Action) => string | boolean,
-        handlePromptAction?: PromptActionCallback,
-    ) => void;
+    register: (id: string, message: (location: History.Location, action: History.Action) => string | boolean, saveAction?: SaveAction) => void;
     unregister: (id: string) => void;
 }
 

--- a/packages/admin/src/router/Context.tsx
+++ b/packages/admin/src/router/Context.tsx
@@ -7,7 +7,7 @@ interface IContext {
     register: (
         id: string,
         message: (location: History.Location, action: History.Action) => string | boolean,
-        handlePromptAction: PromptActionCallback,
+        handlePromptAction?: PromptActionCallback,
     ) => void;
     unregister: (id: string) => void;
 }

--- a/packages/admin/src/router/Prompt.tsx
+++ b/packages/admin/src/router/Prompt.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import useConstant from "use-constant";
 
 import { RouterContext } from "./Context";
-import { PromptActionCallback } from "./PromptHandler";
+import { SaveAction } from "./PromptHandler";
 const UUID = require("uuid");
 
 // react-router Prompt doesn't support multiple Prompts, this one does
@@ -13,14 +13,14 @@ interface IProps {
      * Return a string to show a prompt to the user or true to allow the transition.
      */
     message: (location: History.Location, action: History.Action) => boolean | string;
-    handlePromptAction?: PromptActionCallback;
+    saveAction?: SaveAction;
 }
-export const RouterPrompt: React.FunctionComponent<IProps> = ({ message, handlePromptAction }) => {
+export const RouterPrompt: React.FunctionComponent<IProps> = ({ message, saveAction }) => {
     const id = useConstant<string>(() => UUID.v4());
     const context = React.useContext(RouterContext);
     React.useEffect(() => {
         if (context) {
-            context.register(id, message, handlePromptAction);
+            context.register(id, message, saveAction);
         }
         return function cleanup() {
             if (context) {

--- a/packages/admin/src/router/Prompt.tsx
+++ b/packages/admin/src/router/Prompt.tsx
@@ -13,7 +13,7 @@ interface IProps {
      * Return a string to show a prompt to the user or true to allow the transition.
      */
     message: (location: History.Location, action: History.Action) => boolean | string;
-    handlePromptAction: PromptActionCallback;
+    handlePromptAction?: PromptActionCallback;
 }
 export const RouterPrompt: React.FunctionComponent<IProps> = ({ message, handlePromptAction }) => {
     const id = useConstant<string>(() => UUID.v4());

--- a/packages/admin/src/router/PromptHandler.tsx
+++ b/packages/admin/src/router/PromptHandler.tsx
@@ -14,38 +14,35 @@ interface Props {
     handleDialogClose: (ok: boolean) => void;
 }
 
-export type AllowTransition = boolean;
-export type PromptActionCallback = (action: PromptAction) => Promise<AllowTransition> | AllowTransition;
-interface PromptActionsCallbacks {
-    [id: string]: PromptActionCallback;
+export type SaveActionSuccess = boolean;
+export type SaveAction = (() => Promise<SaveActionSuccess>) | (() => SaveActionSuccess);
+
+interface SaveActions {
+    [id: string]: SaveAction;
 }
 
 export const RouterPromptHandler: React.FunctionComponent<Props> = ({ children, showDialog, dialogMessage, handleDialogClose }) => {
     const registeredMessages = React.useRef<IMessages>({});
-    const promptActions = React.useRef<PromptActionsCallbacks>({});
+    const saveActions = React.useRef<SaveActions>({});
 
-    const register = (
-        id: string,
-        message: (location: History.Location, action: History.Action) => string | boolean,
-        handlePromptAction: PromptActionCallback,
-    ) => {
+    const register = (id: string, message: (location: History.Location, action: History.Action) => string | boolean, saveAction: SaveAction) => {
         registeredMessages.current[id] = message;
-        if (handlePromptAction) {
-            promptActions.current[id] = handlePromptAction;
+        if (saveAction) {
+            saveActions.current[id] = saveAction;
         }
-        // If handlePromptAction is passed it has to be passed for all registered components
-        const countPromptActions = Object.keys(promptActions.current).length;
+        // If saveAction is passed it has to be passed for all registered components
+        const countSaveActions = Object.keys(saveActions.current).length;
         const countRegisteredMessages = Object.keys(registeredMessages.current).length;
-        if (countPromptActions > 0 && countPromptActions !== countRegisteredMessages) {
+        if (countSaveActions > 0 && countSaveActions !== countRegisteredMessages) {
             console.error(
-                "A component (e.g. RouterPrompt) is missing a handlePromptAction-prop. If you fail to do so, the Save-Button in the Dirty-Dialog won't save the changes",
+                "A component (e.g. RouterPrompt) is missing a saveAction-prop. If you fail to do so, the Save-Button in the Dirty-Dialog won't save the changes",
             );
         }
     };
 
     const unregister = (id: string) => {
         delete registeredMessages.current[id];
-        if (promptActions.current[id] !== undefined) delete promptActions.current[id];
+        if (saveActions.current[id] !== undefined) delete saveActions.current[id];
     };
 
     const promptMessage = (location: History.Location, action: History.Action): boolean | string => {
@@ -61,11 +58,9 @@ export const RouterPromptHandler: React.FunctionComponent<Props> = ({ children, 
     };
 
     const handleClose = async (action: PromptAction) => {
-        if (Object.keys(promptActions.current).length > 0) {
-            const results: Array<AllowTransition> = await Promise.all(
-                Object.keys(promptActions.current).map((id) => promptActions.current[id](action)),
-            );
-            handleDialogClose(results.every((result) => result));
+        if (Object.keys(saveActions.current).length > 0 && action === PromptAction.Save) {
+            const results: Array<SaveActionSuccess> = await Promise.all(Object.keys(saveActions.current).map((id) => saveActions.current[id]()));
+            handleDialogClose(results.every((saveActionSuccess) => saveActionSuccess));
         } else {
             handleDialogClose(action === PromptAction.Discard);
         }
@@ -82,7 +77,7 @@ export const RouterPromptHandler: React.FunctionComponent<Props> = ({ children, 
                 isOpen={showDialog}
                 message={dialogMessage}
                 handleClose={handleClose}
-                showSaveButton={Object.keys(promptActions.current).length > 0}
+                showSaveButton={Object.keys(saveActions.current).length > 0}
             />
             <Prompt when={true} message={promptMessage} />
             {children}


### PR DESCRIPTION
Since the DirtyState Confirmation-Dialog is not (yet) configurable it's sufficent to pass a saveAction-Function to implement the Save-Button

Depends on https://github.com/vivid-planet/comet-admin/pull/553