### PR TITLE
Minor theme fixes

### DIFF
--- a/packages/admin/admin-theme/src/componentsTheme/MuiButton.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiButton.ts
@@ -1,8 +1,9 @@
 import { buttonClasses } from "@mui/material";
 import { Palette } from "@mui/material/styles";
 import { Components } from "@mui/material/styles/components";
+import { Typography } from "@mui/material/styles/createTypography";
 
-export const getMuiButton = (palette: Palette): Components["MuiButton"] => ({
+export const getMuiButton = (palette: Palette, typography: Typography): Components["MuiButton"] => ({
     defaultProps: {
         disableElevation: true,
     },
@@ -19,6 +20,7 @@ export const getMuiButton = (palette: Palette): Components["MuiButton"] => ({
             },
         },
         text: ({ ownerState }) => ({
+            fontWeight: typography.fontWeightRegular,
             textTransform: "none",
             paddingTop: 12,
             paddingRight: 15,

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDrawer.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDrawer.ts
@@ -3,6 +3,9 @@ import { Components } from "@mui/material/styles/components";
 
 export const getMuiDrawer = (palette: Palette): Components["MuiDrawer"] => ({
     styleOverrides: {
+        root: {
+            zIndex: 1250, // Between AppBar (1200) and Modal (1300)
+        },
         paper: {
             backgroundColor: palette.grey[50],
         },

--- a/packages/admin/admin-theme/src/componentsTheme/getComponentsTheme.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/getComponentsTheme.ts
@@ -21,7 +21,9 @@ import { getMuiIconButton } from "./MuiIconButton";
 import { getMuiInputAdornment } from "./MuiInputAdornment";
 import { getMuiInputBase } from "./MuiInputBase";
 import { getMuiLink } from "./MuiLink";
+import { getMuiListItem } from "./MuiListItem";
 import { getMuiPaper } from "./MuiPaper";
+import { getMuiPopover } from "./MuiPopover";
 import { getMuiRadio } from "./MuiRadio";
 import { getMuiSelect } from "./MuiSelect";
 import { getMuiSvgIcon } from "./MuiSvgIcon";
@@ -35,34 +37,36 @@ import { getMuiToggleButtonGroup } from "./MuiToggleButtonGroup";
 import { getMuiTypography } from "./MuiTypography";
 
 export const getComponentsTheme = (palette: Palette, typography: Typography, spacing: Spacing): ThemeOptions["components"] => ({
+    MuiAppBar: getMuiAppBar(),
+    MuiAutocomplete: getMuiAutocomplete(spacing),
+    MuiButton: getMuiButton(palette, typography),
+    MuiButtonGroup: getMuiButtonGroup(palette),
+    MuiCardContent: getMuiCardContent(spacing),
     MuiCheckbox: getMuiCheckbox(palette),
-    MuiRadio: getMuiRadio(palette),
     MuiDialog: getMuiDialog(spacing),
-    MuiDialogTitle: getMuiDialogTitle(palette, typography),
+    MuiDialogActions: getMuiDialogActions(palette),
     MuiDialogContent: getMuiDialogContent(palette),
     MuiDialogContentText: getMuiDialogContentText(palette),
-    MuiDialogActions: getMuiDialogActions(palette),
-    MuiButton: getMuiButton(palette),
-    MuiButtonGroup: getMuiButtonGroup(palette),
-    MuiIconButton: getMuiIconButton(palette),
-    MuiTypography: getMuiTypography(),
-    MuiPaper: getMuiPaper(palette),
-    MuiAppBar: getMuiAppBar(),
-    MuiFormLabel: getMuiFormLabel(palette, typography, spacing),
+    MuiDialogTitle: getMuiDialogTitle(palette, typography),
+    MuiDrawer: getMuiDrawer(palette),
     MuiFormControlLabel: getMuiFormControlLabel(),
+    MuiFormLabel: getMuiFormLabel(palette, typography, spacing),
+    MuiIconButton: getMuiIconButton(palette),
+    MuiInputAdornment: getMuiInputAdornment(),
+    MuiInputBase: getMuiInputBase(palette, spacing),
+    MuiLink: getMuiLink(palette),
+    MuiListItem: getMuiListItem(),
+    MuiPaper: getMuiPaper(palette),
+    MuiPopover: getMuiPopover(),
+    MuiRadio: getMuiRadio(palette),
+    MuiSelect: getMuiSelect(palette),
     MuiSvgIcon: getMuiSvgIcon(palette),
     MuiSwitch: getMuiSwitch(palette),
-    MuiSelect: getMuiSelect(palette),
-    MuiDrawer: getMuiDrawer(palette),
-    MuiInputAdornment: getMuiInputAdornment(),
+    MuiTab: getMuiTab(palette, typography),
     MuiTableCell: getMuiTableCell(palette, typography),
     MuiTableRow: getMuiTableRow(),
     MuiTabs: getMuiTabs(palette, spacing),
-    MuiTab: getMuiTab(palette, typography),
-    MuiCardContent: getMuiCardContent(spacing),
-    MuiAutocomplete: getMuiAutocomplete(spacing),
-    MuiInputBase: getMuiInputBase(palette, spacing),
-    MuiLink: getMuiLink(palette),
     MuiToggleButton: getMuiToggleButton(palette),
     MuiToggleButtonGroup: getMuiToggleButtonGroup(palette),
+    MuiTypography: getMuiTypography(),
 });


### PR DESCRIPTION
While updating an application to an alpha relase of Comet Admin v3, I've
encountered some style issues related to the MUI v5 upgrade. This change
resolves the issues by adapting our theme accordingly.

The following changes have been made:

- Change font weight of `text` button variant to `fontWeightRegular`
- Add missing theme options for popover and list item components
- Change z-index of drawer to `1250` to be above app bar