### PR TITLE
Fix Stack Urls

### DIFF
--- a/packages/admin-stories/src/admin/stack/StackUrl.tsx
+++ b/packages/admin-stories/src/admin/stack/StackUrl.tsx
@@ -1,0 +1,58 @@
+import { Stack, StackBreadcrumbs, StackLink, StackPage, StackSwitch } from "@comet/admin";
+import { Link } from "@material-ui/core";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import { useLocation } from "react-router";
+
+import { storyRouterDecorator } from "../../story-router.decorator";
+
+function Story() {
+    const location = useLocation();
+
+    return (
+        <>
+            <p>Pathname: {location.pathname}</p>
+            <Stack topLevelTitle="Stack Url">
+                <StackBreadcrumbs />
+                <StackSwitch>
+                    <StackPage name="page1">
+                        <h3>Page 1</h3>
+                        <Link component={StackLink} pageName="page2" payload="test">
+                            go to page 2
+                        </Link>
+                    </StackPage>
+                    <StackPage name="page2">
+                        <h3>Page 2</h3>
+                        <p>
+                            <Link component={StackLink} pageName="page1" payload="test">
+                                go to page 1
+                            </Link>
+                        </p>
+                        <StackSwitch>
+                            <StackPage name="page2-1">
+                                <h3>Page 2-1</h3>
+                                <p>
+                                    <Link component={StackLink} pageName="page2-2" payload="test">
+                                        go to page 2-2
+                                    </Link>
+                                </p>
+                            </StackPage>
+                            <StackPage name="page2-2">
+                                <h3>Page 2-2</h3>
+                                <p>
+                                    <Link component={StackLink} pageName="page2-1" payload="test">
+                                        go to page 2-1
+                                    </Link>
+                                </p>
+                            </StackPage>
+                        </StackSwitch>
+                    </StackPage>
+                </StackSwitch>
+            </Stack>
+        </>
+    );
+}
+
+storiesOf("@comet/admin/stack", module)
+    .addDecorator(storyRouterDecorator())
+    .add("StackUrl", () => <Story />);

--- a/packages/admin/src/stack/Switch.tsx
+++ b/packages/admin/src/stack/Switch.tsx
@@ -45,6 +45,10 @@ function useUuid() {
     return ref.current;
 }
 
+function removeTrailingSlash(url: string) {
+    return url.replace(/\/$/, "");
+}
+
 export function useStackSwitch(): [React.ComponentType<IProps>, IStackSwitchApi] {
     const apiRef = React.useRef<IStackSwitchApi>(null);
     const id = useUuid();
@@ -100,10 +104,13 @@ const StackSwitchInner: React.RefForwardingComponent<IStackSwitchApi, IProps & I
 
     const getTargetUrl = React.useCallback(
         (pageName: string, payload: string, subUrl?: string): string => {
+            console.log("pageName ", pageName);
+            console.log("payload ", payload);
+            console.log("isInitialPage ", isInitialPage(pageName));
             if (isInitialPage(pageName)) {
-                return match.url;
+                return removeTrailingSlash(match.url);
             } else {
-                return `${match.url}/${payload}/${pageName}${subUrl ? `/${subUrl}` : ""}`;
+                return `${removeTrailingSlash(match.url)}/${payload}/${pageName}${subUrl ? `/${subUrl}` : ""}`;
             }
         },
         [isInitialPage, match.url],
@@ -152,7 +159,10 @@ const StackSwitchInner: React.RefForwardingComponent<IStackSwitchApi, IProps & I
             return ret;
         } else {
             return (
-                <StackBreadcrumb url={routeProps.match.url} title={pageBreadcrumbTitle[page.props.name] || page.props.title || page.props.name}>
+                <StackBreadcrumb
+                    url={removeTrailingSlash(routeProps.match.url)}
+                    title={pageBreadcrumbTitle[page.props.name] || page.props.title || page.props.name}
+                >
                     {ret}
                 </StackBreadcrumb>
             );
@@ -165,7 +175,7 @@ const StackSwitchInner: React.RefForwardingComponent<IStackSwitchApi, IProps & I
         <Switch>
             {React.Children.map(props.children, (page: any) => {
                 if (isInitialPage(page.props.name)) return null; // don't render initial Page
-                const path = `${match.url}/:id/${page.props.name}`;
+                const path = `${removeTrailingSlash(match.url)}/:id/${page.props.name}`;
                 return (
                     <Route path={path}>
                         {(routeProps: RouteComponentProps<IRouteParams>) => {

--- a/packages/admin/src/stack/Switch.tsx
+++ b/packages/admin/src/stack/Switch.tsx
@@ -104,9 +104,6 @@ const StackSwitchInner: React.RefForwardingComponent<IStackSwitchApi, IProps & I
 
     const getTargetUrl = React.useCallback(
         (pageName: string, payload: string, subUrl?: string): string => {
-            console.log("pageName ", pageName);
-            console.log("payload ", payload);
-            console.log("isInitialPage ", isInitialPage(pageName));
             if (isInitialPage(pageName)) {
                 return removeTrailingSlash(match.url);
             } else {


### PR DESCRIPTION
Before this change, all urls in the stack looked like this (two slashes in the beginning):

`//test/page2` (see here: https://comet-admin.netlify.app/?path=/story/comet-admin-stack--stacklink)

Now the urls look like this:

`/test/page2` (see here: https://deploy-preview-603--comet-admin.netlify.app/?path=/story/comet-admin-stack--stackurl)