### PR TITLE
Fix the theme color of MuiIconButton

### DIFF
--- a/packages/admin/admin-stories/src/admin/mui/Buttons.tsx
+++ b/packages/admin/admin-stories/src/admin/mui/Buttons.tsx
@@ -267,8 +267,8 @@ export const Story: React.FC = () => {
                                             </TableCell>
                                             <TableCell>Foo bar</TableCell>
                                             <TableCell align="right">
-                                                <IconButton size="large">
-                                                    <Edit color="primary" />
+                                                <IconButton size="large" color="primary">
+                                                    <Edit />
                                                 </IconButton>
                                                 <IconButton size="large">
                                                     <Favorite />

--- a/packages/admin/admin-theme/src/componentsTheme/MuiIconButton.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiIconButton.ts
@@ -6,5 +6,29 @@ export const getMuiIconButton = (palette: Palette): Components["MuiIconButton"] 
         root: {
             color: palette.grey[900],
         },
+        colorInherit: {
+            color: "inherit",
+        },
+        colorPrimary: {
+            color: palette.primary.main,
+        },
+        colorSecondary: {
+            color: palette.secondary.main,
+        },
+        // The following classes are missing from the type `IconButtonClasses`, but they do exist.
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        colorWarning: {
+            color: palette.warning.main,
+        },
+        colorError: {
+            color: palette.error.main,
+        },
+        colorSuccess: {
+            color: palette.success.main,
+        },
+        colorInfo: {
+            color: palette.info.main,
+        },
     },
 });


### PR DESCRIPTION
The default color, defined in `root`, overrides the color for all other color variants, preventing the ability to set a custom color. Unfortunately, there is no `colorDefault` class that can be accessed, so all colors need to be explicitly re-defined.