### PR TITLE
Replace storybook's deprecated static-dir flag

### DIFF
--- a/packages/admin/admin-stories/.storybook/main.ts
+++ b/packages/admin/admin-stories/.storybook/main.ts
@@ -27,4 +27,5 @@ export default {
             },
         },
     ],
+    staticDirs: ["../public"],
 };

--- a/packages/admin/admin-stories/package.json
+++ b/packages/admin/admin-stories/package.json
@@ -69,8 +69,8 @@
         "yarn-run-all": "^3.0.0"
     },
     "scripts": {
-        "build-storybook": "build-storybook -s public",
-        "storybook": "start-storybook -p 26638 -s public",
+        "build-storybook": "build-storybook",
+        "storybook": "start-storybook -p 26638",
         "lint": "run-p lint:eslint lint:tsc",
         "lint:eslint": "eslint --max-warnings 0 src/",
         "lint:tsc": "tsc --noEmit"


### PR DESCRIPTION
As mentioned in: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated---static-dir-cli-flag