### PR TITLE
Fix overlay style for block preview

### DIFF
--- a/packages/site/site-cms/src/iframebridge/Preview.sc.ts
+++ b/packages/site/site-cms/src/iframebridge/Preview.sc.ts
@@ -1,9 +1,8 @@
 import styled, { css } from "styled-components";
 
 export const Root = styled.div<ISelectionStyleProps>`
+    display: inline-block;
     position: relative;
-    width: inherit;
-    height: inherit;
 `;
 
 export interface ISelectionStyleProps {


### PR DESCRIPTION
The overlay takes the wrong width and height when the parent element has a percentage value by width or height. This problem could be avoided by using an inline element with no specified width or height.
