### PR TITLE
Fix merging of styleOverrides

### DIFF
--- a/packages/admin/admin-theme/package.json
+++ b/packages/admin/admin-theme/package.json
@@ -12,7 +12,7 @@
         "directory": "packages/admin/admin-theme"
     },
     "dependencies": {
-        "lodash.merge": "^4.6.2"
+        "@mui/utils": "^5.4.1"
     },
     "devDependencies": {
         "@babel/cli": "^7.17.6",
@@ -23,7 +23,6 @@
         "@comet/admin-react-select": "^2.0.0",
         "@comet/admin-rte": "^2.0.0",
         "@comet/eslint-config": "^2.0.0",
-        "@types/lodash.merge": "^4.6.6",
         "eslint": "^8.0.0",
         "prettier": "^2.0.0",
         "rimraf": "^3.0.2",

--- a/packages/admin/admin-theme/src/componentsTheme/MuiAppBar.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiAppBar.ts
@@ -1,6 +1,6 @@
-import { Components } from "@mui/material/styles/components";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiAppBar = (): Components["MuiAppBar"] => ({
+export const getMuiAppBar: GetMuiComponentTheme<"MuiAppBar"> = () => ({
     defaultProps: {
         elevation: 0,
     },

--- a/packages/admin/admin-theme/src/componentsTheme/MuiAppBar.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiAppBar.ts
@@ -1,7 +1,9 @@
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiAppBar: GetMuiComponentTheme<"MuiAppBar"> = () => ({
+export const getMuiAppBar: GetMuiComponentTheme<"MuiAppBar"> = (component) => ({
+    ...component,
     defaultProps: {
         elevation: 0,
+        ...component?.defaultProps,
     },
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiAutocomplete.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiAutocomplete.tsx
@@ -1,16 +1,17 @@
 import { Clear } from "@comet/admin-icons";
-import { Components } from "@mui/material/styles/components";
-import { Spacing } from "@mui/system";
 import * as React from "react";
 
-export const getMuiAutocomplete = (spacing: Spacing): Components["MuiAutocomplete"] => ({
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
+
+export const getMuiAutocomplete: GetMuiComponentTheme<"MuiAutocomplete"> = (styleOverrides, { spacing }) => ({
     defaultProps: {
         clearIcon: <Clear color="action" />,
     },
-    styleOverrides: {
+    styleOverrides: mergeOverrideStyles<"MuiAutocomplete">(styleOverrides, {
         endAdornment: {
             top: "auto",
             right: spacing(2),
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiAutocomplete.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiAutocomplete.tsx
@@ -4,11 +4,13 @@ import * as React from "react";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiAutocomplete: GetMuiComponentTheme<"MuiAutocomplete"> = (styleOverrides, { spacing }) => ({
+export const getMuiAutocomplete: GetMuiComponentTheme<"MuiAutocomplete"> = (component, { spacing }) => ({
+    ...component,
     defaultProps: {
         clearIcon: <Clear color="action" />,
+        ...component?.defaultProps,
     },
-    styleOverrides: mergeOverrideStyles<"MuiAutocomplete">(styleOverrides, {
+    styleOverrides: mergeOverrideStyles<"MuiAutocomplete">(component?.styleOverrides, {
         endAdornment: {
             top: "auto",
             right: spacing(2),

--- a/packages/admin/admin-theme/src/componentsTheme/MuiButton.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiButton.ts
@@ -1,13 +1,13 @@
 import { buttonClasses } from "@mui/material";
-import { Palette } from "@mui/material/styles";
-import { Components } from "@mui/material/styles/components";
-import { Typography } from "@mui/material/styles/createTypography";
 
-export const getMuiButton = (palette: Palette, typography: Typography): Components["MuiButton"] => ({
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
+
+export const getMuiButton: GetMuiComponentTheme<"MuiButton"> = (styleOverrides, { palette, typography }) => ({
     defaultProps: {
         disableElevation: true,
     },
-    styleOverrides: {
+    styleOverrides: mergeOverrideStyles<"MuiButton">(styleOverrides, {
         root: {
             position: "relative",
             top: 1,
@@ -111,5 +111,5 @@ export const getMuiButton = (palette: Palette, typography: Typography): Componen
                 fontSize: 16,
             },
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiButton.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiButton.ts
@@ -3,11 +3,13 @@ import { buttonClasses } from "@mui/material";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiButton: GetMuiComponentTheme<"MuiButton"> = (styleOverrides, { palette, typography }) => ({
+export const getMuiButton: GetMuiComponentTheme<"MuiButton"> = (component, { palette, typography }) => ({
+    ...component,
     defaultProps: {
         disableElevation: true,
+        ...component?.defaultProps,
     },
-    styleOverrides: mergeOverrideStyles<"MuiButton">(styleOverrides, {
+    styleOverrides: mergeOverrideStyles<"MuiButton">(component?.styleOverrides, {
         root: {
             position: "relative",
             top: 1,

--- a/packages/admin/admin-theme/src/componentsTheme/MuiButtonGroup.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiButtonGroup.ts
@@ -1,12 +1,13 @@
 import { buttonGroupClasses } from "@mui/material";
-import { Palette } from "@mui/material/styles";
-import { Components } from "@mui/material/styles/components";
 
-export const getMuiButtonGroup = (palette: Palette): Components["MuiButtonGroup"] => ({
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
+
+export const getMuiButtonGroup: GetMuiComponentTheme<"MuiButtonGroup"> = (styleOverrides, { palette }) => ({
     defaultProps: {
         disableElevation: true,
     },
-    styleOverrides: {
+    styleOverrides: mergeOverrideStyles<"MuiButtonGroup">(styleOverrides, {
         contained: {
             border: "none",
         },
@@ -58,5 +59,5 @@ export const getMuiButtonGroup = (palette: Palette): Components["MuiButtonGroup"
                 },
             },
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiButtonGroup.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiButtonGroup.ts
@@ -3,11 +3,13 @@ import { buttonGroupClasses } from "@mui/material";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiButtonGroup: GetMuiComponentTheme<"MuiButtonGroup"> = (styleOverrides, { palette }) => ({
+export const getMuiButtonGroup: GetMuiComponentTheme<"MuiButtonGroup"> = (component, { palette }) => ({
+    ...component,
     defaultProps: {
         disableElevation: true,
+        ...component?.defaultProps,
     },
-    styleOverrides: mergeOverrideStyles<"MuiButtonGroup">(styleOverrides, {
+    styleOverrides: mergeOverrideStyles<"MuiButtonGroup">(component?.styleOverrides, {
         contained: {
             border: "none",
         },

--- a/packages/admin/admin-theme/src/componentsTheme/MuiCardContent.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiCardContent.ts
@@ -1,13 +1,13 @@
-import { Components } from "@mui/material/styles/components";
-import { Spacing } from "@mui/system";
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiCardContent = (spacing: Spacing): Components["MuiCardContent"] => ({
-    styleOverrides: {
+export const getMuiCardContent: GetMuiComponentTheme<"MuiCardContent"> = (styleOverrides, { spacing }) => ({
+    styleOverrides: mergeOverrideStyles<"MuiCardContent">(styleOverrides, {
         root: {
             padding: spacing(4),
             "&:last-child": {
                 paddingBottom: spacing(4),
             },
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiCardContent.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiCardContent.ts
@@ -1,8 +1,9 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiCardContent: GetMuiComponentTheme<"MuiCardContent"> = (styleOverrides, { spacing }) => ({
-    styleOverrides: mergeOverrideStyles<"MuiCardContent">(styleOverrides, {
+export const getMuiCardContent: GetMuiComponentTheme<"MuiCardContent"> = (component, { spacing }) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiCardContent">(component?.styleOverrides, {
         root: {
             padding: spacing(4),
             "&:last-child": {

--- a/packages/admin/admin-theme/src/componentsTheme/MuiCheckbox.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiCheckbox.tsx
@@ -1,16 +1,17 @@
 import { CheckboxChecked, CheckboxUnchecked } from "@comet/admin-icons";
 import { checkboxClasses, svgIconClasses } from "@mui/material";
-import { Palette } from "@mui/material/styles";
-import { Components } from "@mui/material/styles/components";
 import * as React from "react";
 
-export const getMuiCheckbox = (palette: Palette): Components["MuiCheckbox"] => ({
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
+
+export const getMuiCheckbox: GetMuiComponentTheme<"MuiCheckbox"> = (styleOverrides, { palette }) => ({
     defaultProps: {
         color: "primary",
         icon: <CheckboxUnchecked />,
         checkedIcon: <CheckboxChecked />,
     },
-    styleOverrides: {
+    styleOverrides: mergeOverrideStyles<"MuiCheckbox">(styleOverrides, {
         root: {
             [`& .${svgIconClasses.root}`]: {
                 "& .border": {
@@ -56,5 +57,5 @@ export const getMuiCheckbox = (palette: Palette): Components["MuiCheckbox"] => (
                 },
             },
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiCheckbox.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiCheckbox.tsx
@@ -5,13 +5,15 @@ import * as React from "react";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiCheckbox: GetMuiComponentTheme<"MuiCheckbox"> = (styleOverrides, { palette }) => ({
+export const getMuiCheckbox: GetMuiComponentTheme<"MuiCheckbox"> = (component, { palette }) => ({
+    ...component,
     defaultProps: {
         color: "primary",
         icon: <CheckboxUnchecked />,
         checkedIcon: <CheckboxChecked />,
+        ...component?.defaultProps,
     },
-    styleOverrides: mergeOverrideStyles<"MuiCheckbox">(styleOverrides, {
+    styleOverrides: mergeOverrideStyles<"MuiCheckbox">(component?.styleOverrides, {
         root: {
             [`& .${svgIconClasses.root}`]: {
                 "& .border": {

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDialog.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDialog.ts
@@ -1,8 +1,10 @@
 import { Components } from "@mui/material/styles/components";
-import { Spacing } from "@mui/system";
 
-export const getMuiDialog = (spacing: Spacing): Components["MuiDialog"] => ({
-    styleOverrides: {
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
+
+export const getMuiDialog: GetMuiComponentTheme<"MuiDialog"> = (styleOverrides, { spacing }): Components["MuiDialog"] => ({
+    styleOverrides: mergeOverrideStyles<"MuiDialog">(styleOverrides, {
         paper: {
             borderRadius: 4,
             width: "100%",
@@ -29,5 +31,5 @@ export const getMuiDialog = (spacing: Spacing): Components["MuiDialog"] => ({
         paperFullWidth: {
             width: `calc(100% - ${spacing(16)})`,
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDialog.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDialog.ts
@@ -3,8 +3,9 @@ import { Components } from "@mui/material/styles/components";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiDialog: GetMuiComponentTheme<"MuiDialog"> = (styleOverrides, { spacing }): Components["MuiDialog"] => ({
-    styleOverrides: mergeOverrideStyles<"MuiDialog">(styleOverrides, {
+export const getMuiDialog: GetMuiComponentTheme<"MuiDialog"> = (component, { spacing }): Components["MuiDialog"] => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiDialog">(component?.styleOverrides, {
         paper: {
             borderRadius: 4,
             width: "100%",

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDialogActions.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDialogActions.ts
@@ -1,8 +1,8 @@
-import { Palette } from "@mui/material/styles";
-import { Components } from "@mui/material/styles/components";
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiDialogActions = (palette: Palette): Components["MuiDialogActions"] => ({
-    styleOverrides: {
+export const getMuiDialogActions: GetMuiComponentTheme<"MuiDialogActions"> = (styleOverrides, { palette }) => ({
+    styleOverrides: mergeOverrideStyles<"MuiDialogActions">(styleOverrides, {
         root: {
             borderTop: `1px solid ${palette.grey[100]}`,
             padding: 20,
@@ -12,5 +12,5 @@ export const getMuiDialogActions = (palette: Palette): Components["MuiDialogActi
                 marginLeft: "auto",
             },
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDialogActions.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDialogActions.ts
@@ -1,8 +1,9 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiDialogActions: GetMuiComponentTheme<"MuiDialogActions"> = (styleOverrides, { palette }) => ({
-    styleOverrides: mergeOverrideStyles<"MuiDialogActions">(styleOverrides, {
+export const getMuiDialogActions: GetMuiComponentTheme<"MuiDialogActions"> = (component, { palette }) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiDialogActions">(component?.styleOverrides, {
         root: {
             borderTop: `1px solid ${palette.grey[100]}`,
             padding: 20,

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDialogContent.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDialogContent.ts
@@ -1,9 +1,10 @@
 import { dialogTitleClasses } from "@mui/material";
-import { Palette } from "@mui/material/styles";
-import { Components } from "@mui/material/styles/components";
 
-export const getMuiDialogContent = (palette: Palette): Components["MuiDialogContent"] => ({
-    styleOverrides: {
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
+
+export const getMuiDialogContent: GetMuiComponentTheme<"MuiDialogContent"> = (styleOverrides, { palette }) => ({
+    styleOverrides: mergeOverrideStyles<"MuiDialogContent">(styleOverrides, {
         root: {
             backgroundColor: palette.grey[50],
             padding: 40,
@@ -12,5 +13,5 @@ export const getMuiDialogContent = (palette: Palette): Components["MuiDialogCont
                 paddingTop: 40,
             },
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDialogContent.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDialogContent.ts
@@ -3,8 +3,9 @@ import { dialogTitleClasses } from "@mui/material";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiDialogContent: GetMuiComponentTheme<"MuiDialogContent"> = (styleOverrides, { palette }) => ({
-    styleOverrides: mergeOverrideStyles<"MuiDialogContent">(styleOverrides, {
+export const getMuiDialogContent: GetMuiComponentTheme<"MuiDialogContent"> = (component, { palette }) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiDialogContent">(component?.styleOverrides, {
         root: {
             backgroundColor: palette.grey[50],
             padding: 40,

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDialogContentText.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDialogContentText.ts
@@ -1,11 +1,11 @@
-import { Palette } from "@mui/material/styles";
-import { Components } from "@mui/material/styles/components";
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiDialogContentText = (palette: Palette): Components["MuiDialogContentText"] => ({
-    styleOverrides: {
+export const getMuiDialogContentText: GetMuiComponentTheme<"MuiDialogContentText"> = (styleOverrides, { palette }) => ({
+    styleOverrides: mergeOverrideStyles<"MuiDialogContentText">(styleOverrides, {
         root: {
             color: palette.text.primary,
             marginBottom: 20,
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDialogContentText.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDialogContentText.ts
@@ -1,8 +1,9 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiDialogContentText: GetMuiComponentTheme<"MuiDialogContentText"> = (styleOverrides, { palette }) => ({
-    styleOverrides: mergeOverrideStyles<"MuiDialogContentText">(styleOverrides, {
+export const getMuiDialogContentText: GetMuiComponentTheme<"MuiDialogContentText"> = (component, { palette }) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiDialogContentText">(component?.styleOverrides, {
         root: {
             color: palette.text.primary,
             marginBottom: 20,

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDialogTitle.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDialogTitle.ts
@@ -1,9 +1,8 @@
-import { Palette } from "@mui/material/styles";
-import { Components } from "@mui/material/styles/components";
-import { Typography } from "@mui/material/styles/createTypography";
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiDialogTitle = (palette: Palette, typography: Typography): Components["MuiDialogTitle"] => ({
-    styleOverrides: {
+export const getMuiDialogTitle: GetMuiComponentTheme<"MuiDialogTitle"> = (styleOverrides, { palette, typography }) => ({
+    styleOverrides: mergeOverrideStyles<"MuiDialogTitle">(styleOverrides, {
         root: {
             backgroundColor: palette.grey["A200"],
             color: palette.grey["A100"],
@@ -12,5 +11,5 @@ export const getMuiDialogTitle = (palette: Palette, typography: Typography): Com
             lineHeight: "20px",
             fontWeight: typography.fontWeightBold,
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDialogTitle.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDialogTitle.ts
@@ -1,8 +1,9 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiDialogTitle: GetMuiComponentTheme<"MuiDialogTitle"> = (styleOverrides, { palette, typography }) => ({
-    styleOverrides: mergeOverrideStyles<"MuiDialogTitle">(styleOverrides, {
+export const getMuiDialogTitle: GetMuiComponentTheme<"MuiDialogTitle"> = (component, { palette, typography }) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiDialogTitle">(component?.styleOverrides, {
         root: {
             backgroundColor: palette.grey["A200"],
             color: palette.grey["A100"],

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDrawer.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDrawer.ts
@@ -1,13 +1,15 @@
-import { Palette } from "@mui/material/styles";
 import { Components } from "@mui/material/styles/components";
 
-export const getMuiDrawer = (palette: Palette): Components["MuiDrawer"] => ({
-    styleOverrides: {
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
+
+export const getMuiDrawer: GetMuiComponentTheme<"MuiDrawer"> = (styleOverrides, { palette }): Components["MuiDrawer"] => ({
+    styleOverrides: mergeOverrideStyles<"MuiDrawer">(styleOverrides, {
         root: {
             zIndex: 1250, // Between AppBar (1200) and Modal (1300)
         },
         paper: {
             backgroundColor: palette.grey[50],
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiDrawer.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiDrawer.ts
@@ -3,8 +3,9 @@ import { Components } from "@mui/material/styles/components";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiDrawer: GetMuiComponentTheme<"MuiDrawer"> = (styleOverrides, { palette }): Components["MuiDrawer"] => ({
-    styleOverrides: mergeOverrideStyles<"MuiDrawer">(styleOverrides, {
+export const getMuiDrawer: GetMuiComponentTheme<"MuiDrawer"> = (component, { palette }): Components["MuiDrawer"] => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiDrawer">(component?.styleOverrides, {
         root: {
             zIndex: 1250, // Between AppBar (1200) and Modal (1300)
         },

--- a/packages/admin/admin-theme/src/componentsTheme/MuiFormControlLabel.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiFormControlLabel.ts
@@ -1,11 +1,12 @@
-import { Components } from "@mui/material/styles/components";
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiFormControlLabel = (): Components["MuiFormControlLabel"] => ({
-    styleOverrides: {
+export const getMuiFormControlLabel: GetMuiComponentTheme<"MuiFormControlLabel"> = (styleOverrides) => ({
+    styleOverrides: mergeOverrideStyles<"MuiFormControlLabel">(styleOverrides, {
         root: {
             marginLeft: -9,
             marginTop: -7,
             marginBottom: -7,
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiFormControlLabel.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiFormControlLabel.ts
@@ -1,8 +1,9 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiFormControlLabel: GetMuiComponentTheme<"MuiFormControlLabel"> = (styleOverrides) => ({
-    styleOverrides: mergeOverrideStyles<"MuiFormControlLabel">(styleOverrides, {
+export const getMuiFormControlLabel: GetMuiComponentTheme<"MuiFormControlLabel"> = (component) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiFormControlLabel">(component?.styleOverrides, {
         root: {
             marginLeft: -9,
             marginTop: -7,

--- a/packages/admin/admin-theme/src/componentsTheme/MuiFormLabel.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiFormLabel.ts
@@ -1,10 +1,8 @@
-import { Palette } from "@mui/material/styles";
-import { Components } from "@mui/material/styles/components";
-import { Typography } from "@mui/material/styles/createTypography";
-import { Spacing } from "@mui/system";
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiFormLabel = (palette: Palette, typography: Typography, spacing: Spacing): Components["MuiFormLabel"] => ({
-    styleOverrides: {
+export const getMuiFormLabel: GetMuiComponentTheme<"MuiFormLabel"> = (styleOverrides, { palette, typography, spacing }) => ({
+    styleOverrides: mergeOverrideStyles<"MuiFormLabel">(styleOverrides, {
         root: {
             display: "block",
             color: palette.grey[900],
@@ -13,5 +11,5 @@ export const getMuiFormLabel = (palette: Palette, typography: Typography, spacin
             fontWeight: typography.fontWeightBold,
             marginBottom: spacing(2),
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiFormLabel.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiFormLabel.ts
@@ -1,8 +1,9 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiFormLabel: GetMuiComponentTheme<"MuiFormLabel"> = (styleOverrides, { palette, typography, spacing }) => ({
-    styleOverrides: mergeOverrideStyles<"MuiFormLabel">(styleOverrides, {
+export const getMuiFormLabel: GetMuiComponentTheme<"MuiFormLabel"> = (component, { palette, typography, spacing }) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiFormLabel">(component?.styleOverrides, {
         root: {
             display: "block",
             color: palette.grey[900],

--- a/packages/admin/admin-theme/src/componentsTheme/MuiIconButton.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiIconButton.ts
@@ -1,8 +1,8 @@
-import { Palette } from "@mui/material/styles";
-import { Components } from "@mui/material/styles/components";
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiIconButton = (palette: Palette): Components["MuiIconButton"] => ({
-    styleOverrides: {
+export const getMuiIconButton: GetMuiComponentTheme<"MuiIconButton"> = (styleOverrides, { palette }) => ({
+    styleOverrides: mergeOverrideStyles<"MuiIconButton">(styleOverrides, {
         root: {
             color: palette.grey[900],
         },
@@ -30,5 +30,5 @@ export const getMuiIconButton = (palette: Palette): Components["MuiIconButton"] 
         colorInfo: {
             color: palette.info.main,
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiIconButton.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiIconButton.ts
@@ -1,8 +1,9 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiIconButton: GetMuiComponentTheme<"MuiIconButton"> = (styleOverrides, { palette }) => ({
-    styleOverrides: mergeOverrideStyles<"MuiIconButton">(styleOverrides, {
+export const getMuiIconButton: GetMuiComponentTheme<"MuiIconButton"> = (component, { palette }) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiIconButton">(component?.styleOverrides, {
         root: {
             color: palette.grey[900],
         },

--- a/packages/admin/admin-theme/src/componentsTheme/MuiInputAdornment.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiInputAdornment.ts
@@ -1,7 +1,8 @@
-import { Components } from "@mui/material/styles/components";
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiInputAdornment = (): Components["MuiInputAdornment"] => ({
-    styleOverrides: {
+export const getMuiInputAdornment: GetMuiComponentTheme<"MuiInputAdornment"> = (styleOverrides) => ({
+    styleOverrides: mergeOverrideStyles(styleOverrides, {
         root: {
             height: "auto",
             alignSelf: "stretch",
@@ -13,5 +14,5 @@ export const getMuiInputAdornment = (): Components["MuiInputAdornment"] => ({
         positionEnd: {
             marginLeft: 0,
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiInputAdornment.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiInputAdornment.ts
@@ -1,8 +1,9 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiInputAdornment: GetMuiComponentTheme<"MuiInputAdornment"> = (styleOverrides) => ({
-    styleOverrides: mergeOverrideStyles(styleOverrides, {
+export const getMuiInputAdornment: GetMuiComponentTheme<"MuiInputAdornment"> = (component) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles(component?.styleOverrides, {
         root: {
             height: "auto",
             alignSelf: "stretch",

--- a/packages/admin/admin-theme/src/componentsTheme/MuiInputBase.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiInputBase.ts
@@ -1,10 +1,10 @@
 import { inputBaseClasses, svgIconClasses } from "@mui/material";
-import { Palette } from "@mui/material/styles";
-import { Components } from "@mui/material/styles/components";
-import { Spacing } from "@mui/system";
 
-export const getMuiInputBase = (palette: Palette, spacing: Spacing): Components["MuiInputBase"] => ({
-    styleOverrides: {
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
+
+export const getMuiInputBase: GetMuiComponentTheme<"MuiInputBase"> = (styleOverrides, { palette, spacing }) => ({
+    styleOverrides: mergeOverrideStyles<"MuiInputBase">(styleOverrides, {
         root: {
             border: `1px solid ${palette.grey[100]}`,
             borderRadius: 2,
@@ -54,5 +54,5 @@ export const getMuiInputBase = (palette: Palette, spacing: Spacing): Components[
         inputAdornedEnd: {
             paddingRight: spacing(2),
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiInputBase.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiInputBase.ts
@@ -3,8 +3,9 @@ import { inputBaseClasses, svgIconClasses } from "@mui/material";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiInputBase: GetMuiComponentTheme<"MuiInputBase"> = (styleOverrides, { palette, spacing }) => ({
-    styleOverrides: mergeOverrideStyles<"MuiInputBase">(styleOverrides, {
+export const getMuiInputBase: GetMuiComponentTheme<"MuiInputBase"> = (component, { palette, spacing }) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiInputBase">(component?.styleOverrides, {
         root: {
             border: `1px solid ${palette.grey[100]}`,
             borderRadius: 2,

--- a/packages/admin/admin-theme/src/componentsTheme/MuiLink.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiLink.ts
@@ -1,13 +1,13 @@
-import { Palette } from "@mui/material/styles";
-import { Components } from "@mui/material/styles/components";
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiLink = (palette: Palette): Components["MuiLink"] => ({
+export const getMuiLink: GetMuiComponentTheme<"MuiLink"> = (styleOverrides, { palette }) => ({
     defaultProps: {
         underline: "always",
     },
-    styleOverrides: {
+    styleOverrides: mergeOverrideStyles<"MuiLink">(styleOverrides, {
         root: {
             color: palette.grey[600],
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiLink.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiLink.ts
@@ -1,11 +1,13 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiLink: GetMuiComponentTheme<"MuiLink"> = (styleOverrides, { palette }) => ({
+export const getMuiLink: GetMuiComponentTheme<"MuiLink"> = (component, { palette }) => ({
+    ...component,
     defaultProps: {
         underline: "always",
+        ...component?.defaultProps,
     },
-    styleOverrides: mergeOverrideStyles<"MuiLink">(styleOverrides, {
+    styleOverrides: mergeOverrideStyles<"MuiLink">(component?.styleOverrides, {
         root: {
             color: palette.grey[600],
         },

--- a/packages/admin/admin-theme/src/componentsTheme/MuiListItem.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiListItem.ts
@@ -1,6 +1,6 @@
-import { Components } from "@mui/material/styles/components";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiListItem = (): Components["MuiListItem"] => ({
+export const getMuiListItem: GetMuiComponentTheme<"MuiListItem"> = () => ({
     defaultProps: {
         dense: true,
     },

--- a/packages/admin/admin-theme/src/componentsTheme/MuiListItem.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiListItem.ts
@@ -1,7 +1,9 @@
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiListItem: GetMuiComponentTheme<"MuiListItem"> = () => ({
+export const getMuiListItem: GetMuiComponentTheme<"MuiListItem"> = (component) => ({
+    ...component,
     defaultProps: {
         dense: true,
+        ...component?.defaultProps,
     },
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiPaper.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiPaper.ts
@@ -1,16 +1,16 @@
-import { Palette } from "@mui/material/styles";
-import { Components } from "@mui/material/styles/components";
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiPaper = (palette: Palette): Components["MuiPaper"] => ({
+export const getMuiPaper: GetMuiComponentTheme<"MuiPaper"> = (styleOverrides, { palette }) => ({
     defaultProps: {
         square: true,
     },
-    styleOverrides: {
+    styleOverrides: mergeOverrideStyles<"MuiPaper">(styleOverrides, {
         outlined: {
             borderTop: "none",
             borderRight: "none",
             borderBottom: `1px solid ${palette.divider}`,
             borderLeft: "none",
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiPaper.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiPaper.ts
@@ -1,11 +1,13 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiPaper: GetMuiComponentTheme<"MuiPaper"> = (styleOverrides, { palette }) => ({
+export const getMuiPaper: GetMuiComponentTheme<"MuiPaper"> = (component, { palette }) => ({
+    ...component,
     defaultProps: {
         square: true,
+        ...component?.defaultProps,
     },
-    styleOverrides: mergeOverrideStyles<"MuiPaper">(styleOverrides, {
+    styleOverrides: mergeOverrideStyles<"MuiPaper">(component?.styleOverrides, {
         outlined: {
             borderTop: "none",
             borderRight: "none",

--- a/packages/admin/admin-theme/src/componentsTheme/MuiPopover.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiPopover.ts
@@ -1,6 +1,6 @@
-import { Components } from "@mui/material/styles/components";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiPopover = (): Components["MuiPopover"] => ({
+export const getMuiPopover: GetMuiComponentTheme<"MuiPopover"> = () => ({
     defaultProps: {
         elevation: 1,
     },

--- a/packages/admin/admin-theme/src/componentsTheme/MuiPopover.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiPopover.ts
@@ -1,7 +1,9 @@
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiPopover: GetMuiComponentTheme<"MuiPopover"> = () => ({
+export const getMuiPopover: GetMuiComponentTheme<"MuiPopover"> = (component) => ({
+    ...component,
     defaultProps: {
         elevation: 1,
+        ...component?.defaultProps,
     },
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiRadio.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiRadio.tsx
@@ -1,16 +1,18 @@
 import { RadioChecked, RadioUnchecked } from "@comet/admin-icons";
 import { radioClasses, svgIconClasses } from "@mui/material";
-import { Palette } from "@mui/material/styles";
 import { Components } from "@mui/material/styles/components";
 import * as React from "react";
 
-export const getMuiRadio = (palette: Palette): Components["MuiRadio"] => ({
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
+
+export const getMuiRadio: GetMuiComponentTheme<"MuiRadio"> = (styleOverrides, { palette }): Components["MuiRadio"] => ({
     defaultProps: {
         color: "primary",
         icon: <RadioUnchecked />,
         checkedIcon: <RadioChecked />,
     },
-    styleOverrides: {
+    styleOverrides: mergeOverrideStyles<"MuiRadio">(styleOverrides, {
         root: {
             [`& .${svgIconClasses.root}`]: {
                 "& .border": {
@@ -56,5 +58,5 @@ export const getMuiRadio = (palette: Palette): Components["MuiRadio"] => ({
                 },
             },
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiRadio.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiRadio.tsx
@@ -6,13 +6,15 @@ import * as React from "react";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiRadio: GetMuiComponentTheme<"MuiRadio"> = (styleOverrides, { palette }): Components["MuiRadio"] => ({
+export const getMuiRadio: GetMuiComponentTheme<"MuiRadio"> = (component, { palette }): Components["MuiRadio"] => ({
+    ...component,
     defaultProps: {
         color: "primary",
         icon: <RadioUnchecked />,
         checkedIcon: <RadioChecked />,
+        ...component?.defaultProps,
     },
-    styleOverrides: mergeOverrideStyles<"MuiRadio">(styleOverrides, {
+    styleOverrides: mergeOverrideStyles<"MuiRadio">(component?.styleOverrides, {
         root: {
             [`& .${svgIconClasses.root}`]: {
                 "& .border": {

--- a/packages/admin/admin-theme/src/componentsTheme/MuiSelect.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiSelect.tsx
@@ -1,13 +1,14 @@
 import { ChevronDown } from "@comet/admin-icons";
-import { Palette } from "@mui/material/styles";
-import { Components } from "@mui/material/styles/components";
 import * as React from "react";
 
-export const getMuiSelect = (palette: Palette): Components["MuiSelect"] => ({
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
+
+export const getMuiSelect: GetMuiComponentTheme<"MuiSelect"> = (styleOverrides, { palette }) => ({
     defaultProps: {
         IconComponent: ({ className }) => <ChevronDown classes={{ root: className }} />,
     },
-    styleOverrides: {
+    styleOverrides: mergeOverrideStyles<"MuiSelect">(styleOverrides, {
         select: {
             paddingRight: 32,
 
@@ -21,5 +22,5 @@ export const getMuiSelect = (palette: Palette): Components["MuiSelect"] => ({
             fontSize: 12,
             color: palette.grey[900],
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiSelect.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiSelect.tsx
@@ -4,11 +4,13 @@ import * as React from "react";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiSelect: GetMuiComponentTheme<"MuiSelect"> = (styleOverrides, { palette }) => ({
+export const getMuiSelect: GetMuiComponentTheme<"MuiSelect"> = (component, { palette }) => ({
+    ...component,
     defaultProps: {
         IconComponent: ({ className }) => <ChevronDown classes={{ root: className }} />,
+        ...component?.defaultProps,
     },
-    styleOverrides: mergeOverrideStyles<"MuiSelect">(styleOverrides, {
+    styleOverrides: mergeOverrideStyles<"MuiSelect">(component?.styleOverrides, {
         select: {
             paddingRight: 32,
 

--- a/packages/admin/admin-theme/src/componentsTheme/MuiSvgIcon.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiSvgIcon.ts
@@ -1,8 +1,8 @@
-import { Palette } from "@mui/material/styles";
-import { Components } from "@mui/material/styles/components";
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiSvgIcon = (palette: Palette): Components["MuiSvgIcon"] => ({
-    styleOverrides: {
+export const getMuiSvgIcon: GetMuiComponentTheme<"MuiSvgIcon"> = (styleOverrides, { palette }) => ({
+    styleOverrides: mergeOverrideStyles<"MuiSvgIcon">(styleOverrides, {
         root: {
             fontSize: 16,
         },
@@ -15,5 +15,5 @@ export const getMuiSvgIcon = (palette: Palette): Components["MuiSvgIcon"] => ({
         fontSizeLarge: {
             fontSize: 20,
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiSvgIcon.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiSvgIcon.ts
@@ -1,8 +1,9 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiSvgIcon: GetMuiComponentTheme<"MuiSvgIcon"> = (styleOverrides, { palette }) => ({
-    styleOverrides: mergeOverrideStyles<"MuiSvgIcon">(styleOverrides, {
+export const getMuiSvgIcon: GetMuiComponentTheme<"MuiSvgIcon"> = (component, { palette }) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiSvgIcon">(component?.styleOverrides, {
         root: {
             fontSize: 16,
         },

--- a/packages/admin/admin-theme/src/componentsTheme/MuiSwitch.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiSwitch.ts
@@ -1,12 +1,13 @@
 import { switchClasses } from "@mui/material";
-import { Palette } from "@mui/material/styles";
-import { Components } from "@mui/material/styles/components";
 
-export const getMuiSwitch = (palette: Palette): Components["MuiSwitch"] => ({
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
+
+export const getMuiSwitch: GetMuiComponentTheme<"MuiSwitch"> = (styleOverrides, { palette }) => ({
     defaultProps: {
         color: "primary",
     },
-    styleOverrides: {
+    styleOverrides: mergeOverrideStyles<"MuiSwitch">(styleOverrides, {
         root: {
             width: 54,
             height: 34,
@@ -68,5 +69,5 @@ export const getMuiSwitch = (palette: Palette): Components["MuiSwitch"] => ({
             transition: "none",
             backgroundColor: "#fff",
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiSwitch.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiSwitch.ts
@@ -3,11 +3,13 @@ import { switchClasses } from "@mui/material";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiSwitch: GetMuiComponentTheme<"MuiSwitch"> = (styleOverrides, { palette }) => ({
+export const getMuiSwitch: GetMuiComponentTheme<"MuiSwitch"> = (component, { palette }) => ({
+    ...component,
     defaultProps: {
         color: "primary",
+        ...component?.defaultProps,
     },
-    styleOverrides: mergeOverrideStyles<"MuiSwitch">(styleOverrides, {
+    styleOverrides: mergeOverrideStyles<"MuiSwitch">(component?.styleOverrides, {
         root: {
             width: 54,
             height: 34,

--- a/packages/admin/admin-theme/src/componentsTheme/MuiTab.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiTab.ts
@@ -1,10 +1,10 @@
 import { tabClasses } from "@mui/material";
-import { Palette } from "@mui/material/styles";
-import { Components } from "@mui/material/styles/components";
-import { Typography } from "@mui/material/styles/createTypography";
 
-export const getMuiTab = (palette: Palette, typography: Typography): Components["MuiTab"] => ({
-    styleOverrides: {
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
+
+export const getMuiTab: GetMuiComponentTheme<"MuiTab"> = (styleOverrides, { palette, typography }) => ({
+    styleOverrides: mergeOverrideStyles<"MuiTab">(styleOverrides, {
         root: {
             fontSize: 16,
             lineHeight: 1,
@@ -26,5 +26,5 @@ export const getMuiTab = (palette: Palette, typography: Typography): Components[
         textColorInherit: {
             opacity: 1,
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiTab.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiTab.ts
@@ -3,8 +3,9 @@ import { tabClasses } from "@mui/material";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiTab: GetMuiComponentTheme<"MuiTab"> = (styleOverrides, { palette, typography }) => ({
-    styleOverrides: mergeOverrideStyles<"MuiTab">(styleOverrides, {
+export const getMuiTab: GetMuiComponentTheme<"MuiTab"> = (component, { palette, typography }) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiTab">(component?.styleOverrides, {
         root: {
             fontSize: 16,
             lineHeight: 1,

--- a/packages/admin/admin-theme/src/componentsTheme/MuiTableCell.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiTableCell.ts
@@ -1,10 +1,10 @@
 import { buttonClasses, iconButtonClasses } from "@mui/material";
-import { Palette } from "@mui/material/styles";
-import { Components } from "@mui/material/styles/components";
-import { Typography } from "@mui/material/styles/createTypography";
 
-export const getMuiTableCell = (palette: Palette, typography: Typography): Components["MuiTableCell"] => ({
-    styleOverrides: {
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
+
+export const getMuiTableCell: GetMuiComponentTheme<"MuiTableCell"> = (styleOverrides, { palette, typography }) => ({
+    styleOverrides: mergeOverrideStyles<"MuiTableCell">(styleOverrides, {
         root: {
             position: "relative",
             borderBottomColor: palette.grey[100],
@@ -38,5 +38,5 @@ export const getMuiTableCell = (palette: Palette, typography: Typography): Compo
             fontSize: 16,
             lineHeight: "20px",
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiTableCell.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiTableCell.ts
@@ -3,8 +3,9 @@ import { buttonClasses, iconButtonClasses } from "@mui/material";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiTableCell: GetMuiComponentTheme<"MuiTableCell"> = (styleOverrides, { palette, typography }) => ({
-    styleOverrides: mergeOverrideStyles<"MuiTableCell">(styleOverrides, {
+export const getMuiTableCell: GetMuiComponentTheme<"MuiTableCell"> = (component, { palette, typography }) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiTableCell">(component?.styleOverrides, {
         root: {
             position: "relative",
             borderBottomColor: palette.grey[100],

--- a/packages/admin/admin-theme/src/componentsTheme/MuiTableRow.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiTableRow.ts
@@ -1,9 +1,10 @@
-import { Components } from "@mui/material/styles/components";
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiTableRow = (): Components["MuiTableRow"] => ({
-    styleOverrides: {
+export const getMuiTableRow: GetMuiComponentTheme<"MuiTableRow"> = (styleOverrides) => ({
+    styleOverrides: mergeOverrideStyles<"MuiTableRow">(styleOverrides, {
         root: {
             backgroundColor: "#fff",
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiTableRow.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiTableRow.ts
@@ -1,8 +1,9 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiTableRow: GetMuiComponentTheme<"MuiTableRow"> = (styleOverrides) => ({
-    styleOverrides: mergeOverrideStyles<"MuiTableRow">(styleOverrides, {
+export const getMuiTableRow: GetMuiComponentTheme<"MuiTableRow"> = (component) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiTableRow">(component?.styleOverrides, {
         root: {
             backgroundColor: "#fff",
         },

--- a/packages/admin/admin-theme/src/componentsTheme/MuiTabs.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiTabs.ts
@@ -1,9 +1,8 @@
-import { Palette } from "@mui/material/styles";
-import { Components } from "@mui/material/styles/components";
-import { Spacing } from "@mui/system";
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiTabs = (palette: Palette, spacing: Spacing): Components["MuiTabs"] => ({
-    styleOverrides: {
+export const getMuiTabs: GetMuiComponentTheme<"MuiTabs"> = (styleOverrides, { palette, spacing }) => ({
+    styleOverrides: mergeOverrideStyles<"MuiTabs">(styleOverrides, {
         root: {
             position: "relative",
             marginBottom: spacing(4),
@@ -25,5 +24,5 @@ export const getMuiTabs = (palette: Palette, spacing: Spacing): Components["MuiT
             backgroundColor: palette.primary.main,
             height: 2,
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiTabs.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiTabs.ts
@@ -1,8 +1,9 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiTabs: GetMuiComponentTheme<"MuiTabs"> = (styleOverrides, { palette, spacing }) => ({
-    styleOverrides: mergeOverrideStyles<"MuiTabs">(styleOverrides, {
+export const getMuiTabs: GetMuiComponentTheme<"MuiTabs"> = (component, { palette, spacing }) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiTabs">(component?.styleOverrides, {
         root: {
             position: "relative",
             marginBottom: spacing(4),

--- a/packages/admin/admin-theme/src/componentsTheme/MuiToggleButton.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiToggleButton.ts
@@ -1,9 +1,10 @@
 import { toggleButtonClasses } from "@mui/material";
-import { Palette } from "@mui/material/styles";
-import { Components } from "@mui/material/styles/components";
 
-export const getMuiToggleButton = (palette: Palette): Components["MuiToggleButton"] => ({
-    styleOverrides: {
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
+
+export const getMuiToggleButton: GetMuiComponentTheme<"MuiToggleButton"> = (styleOverrides, { palette }) => ({
+    styleOverrides: mergeOverrideStyles<"MuiToggleButton">(styleOverrides, {
         root: {
             borderColor: palette.grey[100],
 
@@ -13,5 +14,5 @@ export const getMuiToggleButton = (palette: Palette): Components["MuiToggleButto
                 color: palette.primary.main,
             },
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiToggleButton.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiToggleButton.ts
@@ -3,8 +3,9 @@ import { toggleButtonClasses } from "@mui/material";
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiToggleButton: GetMuiComponentTheme<"MuiToggleButton"> = (styleOverrides, { palette }) => ({
-    styleOverrides: mergeOverrideStyles<"MuiToggleButton">(styleOverrides, {
+export const getMuiToggleButton: GetMuiComponentTheme<"MuiToggleButton"> = (component, { palette }) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiToggleButton">(component?.styleOverrides, {
         root: {
             borderColor: palette.grey[100],
 

--- a/packages/admin/admin-theme/src/componentsTheme/MuiToggleButtonGroup.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiToggleButtonGroup.ts
@@ -1,11 +1,11 @@
-import { Palette } from "@mui/material/styles";
-import { Components } from "@mui/material/styles/components";
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiToggleButtonGroup = (palette: Palette): Components["MuiToggleButtonGroup"] => ({
-    styleOverrides: {
+export const getMuiToggleButtonGroup: GetMuiComponentTheme<"MuiToggleButtonGroup"> = (styleOverrides, { palette }) => ({
+    styleOverrides: mergeOverrideStyles<"MuiToggleButtonGroup">(styleOverrides, {
         root: {
             backgroundColor: palette.common.white,
             borderRadius: 1,
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiToggleButtonGroup.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiToggleButtonGroup.ts
@@ -1,8 +1,9 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiToggleButtonGroup: GetMuiComponentTheme<"MuiToggleButtonGroup"> = (styleOverrides, { palette }) => ({
-    styleOverrides: mergeOverrideStyles<"MuiToggleButtonGroup">(styleOverrides, {
+export const getMuiToggleButtonGroup: GetMuiComponentTheme<"MuiToggleButtonGroup"> = (component, { palette }) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiToggleButtonGroup">(component?.styleOverrides, {
         root: {
             backgroundColor: palette.common.white,
             borderRadius: 1,

--- a/packages/admin/admin-theme/src/componentsTheme/MuiTypography.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiTypography.ts
@@ -1,9 +1,10 @@
-import { Components } from "@mui/material/styles/components";
+import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
+import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiTypography = (): Components["MuiTypography"] => ({
-    styleOverrides: {
+export const getMuiTypography: GetMuiComponentTheme<"MuiTypography"> = (styleOverrides) => ({
+    styleOverrides: mergeOverrideStyles<"MuiTypography">(styleOverrides, {
         gutterBottom: {
             marginBottom: 20,
         },
-    },
+    }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiTypography.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiTypography.ts
@@ -1,8 +1,9 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiTypography: GetMuiComponentTheme<"MuiTypography"> = (styleOverrides) => ({
-    styleOverrides: mergeOverrideStyles<"MuiTypography">(styleOverrides, {
+export const getMuiTypography: GetMuiComponentTheme<"MuiTypography"> = (component) => ({
+    ...component,
+    styleOverrides: mergeOverrideStyles<"MuiTypography">(component?.styleOverrides, {
         gutterBottom: {
             marginBottom: 20,
         },

--- a/packages/admin/admin-theme/src/componentsTheme/getComponentsTheme.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/getComponentsTheme.ts
@@ -1,5 +1,5 @@
-import { ThemeOptions } from "@mui/material";
-import { Palette } from "@mui/material/styles/createPalette";
+import { ComponentNameToClassKey, Theme, ThemeOptions } from "@mui/material";
+import { Components, ComponentsOverrides, Palette } from "@mui/material/styles";
 import { Typography } from "@mui/material/styles/createTypography";
 import { Spacing } from "@mui/system";
 
@@ -36,37 +36,48 @@ import { getMuiToggleButton } from "./MuiToggleButton";
 import { getMuiToggleButtonGroup } from "./MuiToggleButtonGroup";
 import { getMuiTypography } from "./MuiTypography";
 
-export const getComponentsTheme = (palette: Palette, typography: Typography, spacing: Spacing): ThemeOptions["components"] => ({
-    MuiAppBar: getMuiAppBar(),
-    MuiAutocomplete: getMuiAutocomplete(spacing),
-    MuiButton: getMuiButton(palette, typography),
-    MuiButtonGroup: getMuiButtonGroup(palette),
-    MuiCardContent: getMuiCardContent(spacing),
-    MuiCheckbox: getMuiCheckbox(palette),
-    MuiDialog: getMuiDialog(spacing),
-    MuiDialogActions: getMuiDialogActions(palette),
-    MuiDialogContent: getMuiDialogContent(palette),
-    MuiDialogContentText: getMuiDialogContentText(palette),
-    MuiDialogTitle: getMuiDialogTitle(palette, typography),
-    MuiDrawer: getMuiDrawer(palette),
-    MuiFormControlLabel: getMuiFormControlLabel(),
-    MuiFormLabel: getMuiFormLabel(palette, typography, spacing),
-    MuiIconButton: getMuiIconButton(palette),
-    MuiInputAdornment: getMuiInputAdornment(),
-    MuiInputBase: getMuiInputBase(palette, spacing),
-    MuiLink: getMuiLink(palette),
-    MuiListItem: getMuiListItem(),
-    MuiPaper: getMuiPaper(palette),
-    MuiPopover: getMuiPopover(),
-    MuiRadio: getMuiRadio(palette),
-    MuiSelect: getMuiSelect(palette),
-    MuiSvgIcon: getMuiSvgIcon(palette),
-    MuiSwitch: getMuiSwitch(palette),
-    MuiTab: getMuiTab(palette, typography),
-    MuiTableCell: getMuiTableCell(palette, typography),
-    MuiTableRow: getMuiTableRow(),
-    MuiTabs: getMuiTabs(palette, spacing),
-    MuiToggleButton: getMuiToggleButton(palette),
-    MuiToggleButtonGroup: getMuiToggleButtonGroup(palette),
-    MuiTypography: getMuiTypography(),
+type ThemeData = {
+    palette: Palette;
+    typography: Typography;
+    spacing: Spacing;
+};
+
+export type GetMuiComponentTheme<ClassesName extends keyof ComponentNameToClassKey> = (
+    styleOverrides: ComponentsOverrides<Theme>[ClassesName],
+    themeData: ThemeData,
+) => Components[ClassesName];
+
+export const getComponentsTheme = (components: Components, themeData: ThemeData): ThemeOptions["components"] => ({
+    MuiAppBar: getMuiAppBar(components.MuiAppBar?.styleOverrides, themeData),
+    MuiAutocomplete: getMuiAutocomplete(components.MuiAutocomplete?.styleOverrides, themeData),
+    MuiButton: getMuiButton(components.MuiButton?.styleOverrides, themeData),
+    MuiButtonGroup: getMuiButtonGroup(components.MuiButtonGroup?.styleOverrides, themeData),
+    MuiCardContent: getMuiCardContent(components.MuiCardContent?.styleOverrides, themeData),
+    MuiCheckbox: getMuiCheckbox(components.MuiCheckbox?.styleOverrides, themeData),
+    MuiDialog: getMuiDialog(components.MuiDialog?.styleOverrides, themeData),
+    MuiDialogActions: getMuiDialogActions(components.MuiDialogActions?.styleOverrides, themeData),
+    MuiDialogContent: getMuiDialogContent(components.MuiDialogContent?.styleOverrides, themeData),
+    MuiDialogContentText: getMuiDialogContentText(components.MuiDialogContentText?.styleOverrides, themeData),
+    MuiDialogTitle: getMuiDialogTitle(components.MuiDialogTitle?.styleOverrides, themeData),
+    MuiDrawer: getMuiDrawer(components.MuiDrawer?.styleOverrides, themeData),
+    MuiFormControlLabel: getMuiFormControlLabel(components.MuiFormControlLabel?.styleOverrides, themeData),
+    MuiFormLabel: getMuiFormLabel(components.MuiFormLabel?.styleOverrides, themeData),
+    MuiIconButton: getMuiIconButton(components.MuiIconButton?.styleOverrides, themeData),
+    MuiInputAdornment: getMuiInputAdornment(components.MuiInputAdornment?.styleOverrides, themeData),
+    MuiInputBase: getMuiInputBase(components.MuiInputBase?.styleOverrides, themeData),
+    MuiLink: getMuiLink(components.MuiLink?.styleOverrides, themeData),
+    MuiListItem: getMuiListItem(components.MuiListItem?.styleOverrides, themeData),
+    MuiPaper: getMuiPaper(components.MuiPaper?.styleOverrides, themeData),
+    MuiPopover: getMuiPopover(components.MuiPopover?.styleOverrides, themeData),
+    MuiRadio: getMuiRadio(components.MuiRadio?.styleOverrides, themeData),
+    MuiSelect: getMuiSelect(components.MuiSelect?.styleOverrides, themeData),
+    MuiSvgIcon: getMuiSvgIcon(components.MuiSvgIcon?.styleOverrides, themeData),
+    MuiSwitch: getMuiSwitch(components.MuiSwitch?.styleOverrides, themeData),
+    MuiTab: getMuiTab(components.MuiTab?.styleOverrides, themeData),
+    MuiTableCell: getMuiTableCell(components.MuiTableCell?.styleOverrides, themeData),
+    MuiTableRow: getMuiTableRow(components.MuiTableRow?.styleOverrides, themeData),
+    MuiTabs: getMuiTabs(components.MuiTabs?.styleOverrides, themeData),
+    MuiToggleButton: getMuiToggleButton(components.MuiToggleButton?.styleOverrides, themeData),
+    MuiToggleButtonGroup: getMuiToggleButtonGroup(components.MuiToggleButtonGroup?.styleOverrides, themeData),
+    MuiTypography: getMuiTypography(components.MuiTypography?.styleOverrides, themeData),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/getComponentsTheme.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/getComponentsTheme.ts
@@ -1,5 +1,5 @@
-import { ComponentNameToClassKey, Theme, ThemeOptions } from "@mui/material";
-import { Components, ComponentsOverrides, Palette } from "@mui/material/styles";
+import { ComponentNameToClassKey, ThemeOptions } from "@mui/material";
+import { Components, Palette } from "@mui/material/styles";
 import { Typography } from "@mui/material/styles/createTypography";
 import { Spacing } from "@mui/system";
 
@@ -43,41 +43,42 @@ type ThemeData = {
 };
 
 export type GetMuiComponentTheme<ClassesName extends keyof ComponentNameToClassKey> = (
-    styleOverrides: ComponentsOverrides<Theme>[ClassesName],
+    component: Components[ClassesName],
     themeData: ThemeData,
 ) => Components[ClassesName];
 
 export const getComponentsTheme = (components: Components, themeData: ThemeData): ThemeOptions["components"] => ({
-    MuiAppBar: getMuiAppBar(components.MuiAppBar?.styleOverrides, themeData),
-    MuiAutocomplete: getMuiAutocomplete(components.MuiAutocomplete?.styleOverrides, themeData),
-    MuiButton: getMuiButton(components.MuiButton?.styleOverrides, themeData),
-    MuiButtonGroup: getMuiButtonGroup(components.MuiButtonGroup?.styleOverrides, themeData),
-    MuiCardContent: getMuiCardContent(components.MuiCardContent?.styleOverrides, themeData),
-    MuiCheckbox: getMuiCheckbox(components.MuiCheckbox?.styleOverrides, themeData),
-    MuiDialog: getMuiDialog(components.MuiDialog?.styleOverrides, themeData),
-    MuiDialogActions: getMuiDialogActions(components.MuiDialogActions?.styleOverrides, themeData),
-    MuiDialogContent: getMuiDialogContent(components.MuiDialogContent?.styleOverrides, themeData),
-    MuiDialogContentText: getMuiDialogContentText(components.MuiDialogContentText?.styleOverrides, themeData),
-    MuiDialogTitle: getMuiDialogTitle(components.MuiDialogTitle?.styleOverrides, themeData),
-    MuiDrawer: getMuiDrawer(components.MuiDrawer?.styleOverrides, themeData),
-    MuiFormControlLabel: getMuiFormControlLabel(components.MuiFormControlLabel?.styleOverrides, themeData),
-    MuiFormLabel: getMuiFormLabel(components.MuiFormLabel?.styleOverrides, themeData),
-    MuiIconButton: getMuiIconButton(components.MuiIconButton?.styleOverrides, themeData),
-    MuiInputAdornment: getMuiInputAdornment(components.MuiInputAdornment?.styleOverrides, themeData),
-    MuiInputBase: getMuiInputBase(components.MuiInputBase?.styleOverrides, themeData),
-    MuiLink: getMuiLink(components.MuiLink?.styleOverrides, themeData),
-    MuiListItem: getMuiListItem(components.MuiListItem?.styleOverrides, themeData),
-    MuiPaper: getMuiPaper(components.MuiPaper?.styleOverrides, themeData),
-    MuiPopover: getMuiPopover(components.MuiPopover?.styleOverrides, themeData),
-    MuiRadio: getMuiRadio(components.MuiRadio?.styleOverrides, themeData),
-    MuiSelect: getMuiSelect(components.MuiSelect?.styleOverrides, themeData),
-    MuiSvgIcon: getMuiSvgIcon(components.MuiSvgIcon?.styleOverrides, themeData),
-    MuiSwitch: getMuiSwitch(components.MuiSwitch?.styleOverrides, themeData),
-    MuiTab: getMuiTab(components.MuiTab?.styleOverrides, themeData),
-    MuiTableCell: getMuiTableCell(components.MuiTableCell?.styleOverrides, themeData),
-    MuiTableRow: getMuiTableRow(components.MuiTableRow?.styleOverrides, themeData),
-    MuiTabs: getMuiTabs(components.MuiTabs?.styleOverrides, themeData),
-    MuiToggleButton: getMuiToggleButton(components.MuiToggleButton?.styleOverrides, themeData),
-    MuiToggleButtonGroup: getMuiToggleButtonGroup(components.MuiToggleButtonGroup?.styleOverrides, themeData),
-    MuiTypography: getMuiTypography(components.MuiTypography?.styleOverrides, themeData),
+    ...components,
+    MuiAppBar: getMuiAppBar(components.MuiAppBar, themeData),
+    MuiAutocomplete: getMuiAutocomplete(components.MuiAutocomplete, themeData),
+    MuiButton: getMuiButton(components.MuiButton, themeData),
+    MuiButtonGroup: getMuiButtonGroup(components.MuiButtonGroup, themeData),
+    MuiCardContent: getMuiCardContent(components.MuiCardContent, themeData),
+    MuiCheckbox: getMuiCheckbox(components.MuiCheckbox, themeData),
+    MuiDialog: getMuiDialog(components.MuiDialog, themeData),
+    MuiDialogActions: getMuiDialogActions(components.MuiDialogActions, themeData),
+    MuiDialogContent: getMuiDialogContent(components.MuiDialogContent, themeData),
+    MuiDialogContentText: getMuiDialogContentText(components.MuiDialogContentText, themeData),
+    MuiDialogTitle: getMuiDialogTitle(components.MuiDialogTitle, themeData),
+    MuiDrawer: getMuiDrawer(components.MuiDrawer, themeData),
+    MuiFormControlLabel: getMuiFormControlLabel(components.MuiFormControlLabel, themeData),
+    MuiFormLabel: getMuiFormLabel(components.MuiFormLabel, themeData),
+    MuiIconButton: getMuiIconButton(components.MuiIconButton, themeData),
+    MuiInputAdornment: getMuiInputAdornment(components.MuiInputAdornment, themeData),
+    MuiInputBase: getMuiInputBase(components.MuiInputBase, themeData),
+    MuiLink: getMuiLink(components.MuiLink, themeData),
+    MuiListItem: getMuiListItem(components.MuiListItem, themeData),
+    MuiPaper: getMuiPaper(components.MuiPaper, themeData),
+    MuiPopover: getMuiPopover(components.MuiPopover, themeData),
+    MuiRadio: getMuiRadio(components.MuiRadio, themeData),
+    MuiSelect: getMuiSelect(components.MuiSelect, themeData),
+    MuiSvgIcon: getMuiSvgIcon(components.MuiSvgIcon, themeData),
+    MuiSwitch: getMuiSwitch(components.MuiSwitch, themeData),
+    MuiTab: getMuiTab(components.MuiTab, themeData),
+    MuiTableCell: getMuiTableCell(components.MuiTableCell, themeData),
+    MuiTableRow: getMuiTableRow(components.MuiTableRow, themeData),
+    MuiTabs: getMuiTabs(components.MuiTabs, themeData),
+    MuiToggleButton: getMuiToggleButton(components.MuiToggleButton, themeData),
+    MuiToggleButtonGroup: getMuiToggleButtonGroup(components.MuiToggleButtonGroup, themeData),
+    MuiTypography: getMuiTypography(components.MuiTypography, themeData),
 });

--- a/packages/admin/admin-theme/src/createCometTheme.ts
+++ b/packages/admin/admin-theme/src/createCometTheme.ts
@@ -1,42 +1,42 @@
 import { createTheme, Theme, ThemeOptions } from "@mui/material";
-import { Palette, PaletteOptions } from "@mui/material/styles";
-import createPalette from "@mui/material/styles/createPalette";
-import createTypography, { Typography, TypographyOptions } from "@mui/material/styles/createTypography";
-import { createSpacing, Spacing, SpacingOptions } from "@mui/system";
-import merge from "lodash.merge";
+import createPalette, { PaletteOptions } from "@mui/material/styles/createPalette";
+import createTypography, { TypographyOptions } from "@mui/material/styles/createTypography";
+import { createSpacing } from "@mui/system";
+import { deepmerge } from "@mui/utils";
 
 import { getComponentsTheme } from "./componentsTheme/getComponentsTheme";
 import { paletteOptions as cometPaletteOptions } from "./paletteOptions";
 import { shadows } from "./shadows";
 import { typographyOptions as cometTypographyOptions } from "./typographyOptions";
 
-export const createCometTheme = (customThemeOptions: ThemeOptions | undefined = {}): Theme => {
-    const customPaletteOptions: PaletteOptions = customThemeOptions?.palette ? customThemeOptions.palette : {};
-    const paletteOptions: PaletteOptions = merge(cometPaletteOptions, customPaletteOptions);
-    const palette: Palette = createPalette(paletteOptions);
+export const createCometTheme = ({
+    palette: passedPaletteOptions = {},
+    typography: passedTypographyOptions = {},
+    spacing: passedSpacingOptions = 5,
+    components: passedComponentsOptions = {},
+    ...restPassedOptions
+}: ThemeOptions | undefined = {}): Theme => {
+    const paletteOptions: PaletteOptions = deepmerge<PaletteOptions>(cometPaletteOptions, passedPaletteOptions);
+    const palette = createPalette(paletteOptions);
 
-    const customTypographyOptions: TypographyOptions | ((palette: Palette) => TypographyOptions) = customThemeOptions?.typography
-        ? customThemeOptions.typography
-        : {};
-    const customTypographyOptionsObject: TypographyOptions =
-        typeof customTypographyOptions === "function" ? customTypographyOptions(palette) : customTypographyOptions;
-    const typographyOptions: TypographyOptions = merge(cometTypographyOptions, customTypographyOptionsObject);
-    const typography: Typography = createTypography(palette, typographyOptions);
+    const passedTypographyOptionsObject: TypographyOptions =
+        typeof passedTypographyOptions === "function" ? passedTypographyOptions(palette) : passedTypographyOptions;
+    const typographyOptions: TypographyOptions = deepmerge<TypographyOptions>(cometTypographyOptions, passedTypographyOptionsObject);
+    const typography = createTypography(palette, typographyOptions);
 
-    const spacingOptions: SpacingOptions = customThemeOptions?.spacing === undefined ? 5 : customThemeOptions.spacing;
-    const spacing: Spacing = createSpacing(spacingOptions);
+    const spacing = createSpacing(passedSpacingOptions);
 
     const cometThemeOptions: ThemeOptions = {
-        spacing: spacingOptions,
+        spacing: passedSpacingOptions,
         palette: paletteOptions,
         typography: typographyOptions,
         shape: {
             borderRadius: 2,
         },
         shadows,
-        components: getComponentsTheme(palette, typography, spacing),
+        components: getComponentsTheme(passedComponentsOptions, { palette, typography, spacing }),
     };
 
-    const themeOptions: ThemeOptions = merge(cometThemeOptions, customThemeOptions);
+    const themeOptions = deepmerge<ThemeOptions>(cometThemeOptions, restPassedOptions);
     return createTheme(themeOptions);
 };

--- a/packages/admin/admin-theme/src/utils/mergeOverrideStyles.ts
+++ b/packages/admin/admin-theme/src/utils/mergeOverrideStyles.ts
@@ -1,0 +1,45 @@
+import { CSSInterpolation, Theme } from "@mui/material";
+import { ComponentNameToClassKey, OverridesStyleRules } from "@mui/material/styles/overrides";
+import { ComponentsPropsList } from "@mui/material/styles/props";
+import { deepmerge } from "@mui/utils";
+
+type OwnerState<PropsName extends keyof ComponentsPropsList> = PropsName extends keyof ComponentsPropsList
+    ? { ownerState: ComponentsPropsList[PropsName] & Record<string, unknown> }
+    : Record<string, unknown>;
+
+type OverrideProps<PropsName extends keyof ComponentsPropsList> = OwnerState<PropsName> & { theme: Theme } & Record<string, unknown>;
+
+type ClassKey<ClassesName extends keyof ComponentNameToClassKey> = ComponentNameToClassKey[ClassesName];
+
+const getOverridesInterpolation = <PropsName extends keyof ComponentsPropsList>(
+    props: OverrideProps<PropsName>,
+    overrides?: CSSInterpolation | ((props: OverrideProps<PropsName>) => CSSInterpolation) | undefined,
+): CSSInterpolation => {
+    if (typeof overrides === "undefined") {
+        return {};
+    }
+
+    if (typeof overrides === "function") {
+        return overrides(props);
+    }
+
+    return overrides;
+};
+
+export const mergeOverrideStyles = <ComponentName extends keyof ComponentNameToClassKey & keyof ComponentsPropsList>(
+    passedIn: Partial<OverridesStyleRules<ClassKey<ComponentName>>> = {},
+    comet: Partial<OverridesStyleRules<ClassKey<ComponentName>>> = {},
+): Partial<OverridesStyleRules<ClassKey<ComponentName>>> => {
+    const mergedOverrides = { ...comet };
+
+    Object.keys(passedIn).forEach((classKey: ClassKey<ComponentName>) => {
+        mergedOverrides[classKey] = (props: OverrideProps<ComponentName>) => {
+            return deepmerge<CSSInterpolation>(
+                getOverridesInterpolation<ComponentName>(props, comet[classKey]),
+                getOverridesInterpolation<ComponentName>(props, passedIn[classKey]),
+            );
+        };
+    });
+
+    return mergedOverrides;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3187,9 +3187,8 @@ __metadata:
     "@comet/admin-react-select": ^2.0.0
     "@comet/admin-rte": ^2.0.0
     "@comet/eslint-config": ^2.0.0
-    "@types/lodash.merge": ^4.6.6
+    "@mui/utils": ^5.4.1
     eslint: ^8.0.0
-    lodash.merge: ^4.6.2
     prettier: ^2.0.0
     rimraf: ^3.0.2
     typescript: ^4.0.0
@@ -6119,6 +6118,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/utils@npm:^5.4.1":
+  version: 5.7.0
+  resolution: "@mui/utils@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": ^7.17.2
+    "@types/prop-types": ^15.7.5
+    "@types/react-is": ^16.7.1 || ^17.0.0
+    prop-types: ^15.8.1
+    react-is: ^17.0.2
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+  checksum: b2777938fb85b8819452ade6dce06a7760e7bf0624ab9ccb63394d158c30a0bb07a88df734a3d931bca4f80ab78648324bbebb8b1419c9b88904651bb4c2d6bc
+  languageName: node
+  linkType: hard
+
 "@mui/utils@npm:^5.6.0":
   version: 5.6.0
   resolution: "@mui/utils@npm:5.6.0"
@@ -8555,15 +8569,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash.merge@npm:^4.6.6":
-  version: 4.6.6
-  resolution: "@types/lodash.merge@npm:4.6.6"
-  dependencies:
-    "@types/lodash": "*"
-  checksum: 62ec56f14b3077f7174497856e9b277db811943cd11b1d67d2a8e51a1803bd49319e8aaf62e745c696af972354a575dbb8a85d3aecf4ae774caf062dc31ac46e
-  languageName: node
-  linkType: hard
-
 "@types/lodash.set@npm:^4.3.6":
   version: 4.3.7
   resolution: "@types/lodash.set@npm:4.3.7"
@@ -8765,6 +8770,13 @@ __metadata:
   version: 15.7.4
   resolution: "@types/prop-types@npm:15.7.4"
   checksum: ef6e1899e59b876c273811b1bd845022fc66d5a3d11cb38a25b6c566b30514ae38fe20a40f67622f362a4f4f7f9224e22d8da101cff3d6e97e11d7b4c307cfc1
+  languageName: node
+  linkType: hard
+
+"@types/prop-types@npm:^15.7.5":
+  version: 15.7.5
+  resolution: "@types/prop-types@npm:15.7.5"
+  checksum: 5b43b8b15415e1f298243165f1d44390403bb2bd42e662bca3b5b5633fdd39c938e91b7fce3a9483699db0f7a715d08cef220c121f723a634972fdf596aec980
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
A component's `styleOverrides` can be either an object or a function that returns an object. Until recently, the `styleOverrides` inside `@comet/admin-theme` and likely those defined in the application were all objects. Therefore merging the two (the comet theme options and the theme options defined in an application) always worked.

When updating to MUI 5, some `styleOverrides` inside `@comet/admin-theme` were changed to functions. This would cause the application-defined `styleOverrides` to replace the function instead of merging them and removing the comet styles.

With `mergeOverrideStyles`, a new overrides function is created, which calls the overrides-functions and merges their resulting objects.