### PR TITLE
Fix split preview minimizing

### DIFF
--- a/packages/admin/admin-cms/src/preview/SplitPreview.sc.ts
+++ b/packages/admin/admin-cms/src/preview/SplitPreview.sc.ts
@@ -72,7 +72,7 @@ export const PreviewContainer = styled("div")<PreviewContainerProps>`
     ${({ minimized, theme }) =>
         minimized &&
         css`
-            transform: translateZ(0) translateY(${-theme.spacing(4)}) scale(0.1);
+            transform: translateZ(0) translateY(-${theme.spacing(4)}) scale(0.1);
             border-radius: 50px;
             overflow: hidden;
         `}


### PR DESCRIPTION
The MUI v5 upgrade introduced a bug where the `transform` style of the split preview is not applied correctly. This was caused by a change to the MUI `spacing` function, which now automatically appends "px" to the value, causing the (negated) value of the y-axis translation to be an invalid number. To resolve the issue, the negation has been moved before the placeholder.

**Before**

<img width="200" alt="before" src="https://user-images.githubusercontent.com/48853629/168625700-3f1ce1a7-e064-4868-8205-ab05e96ed5b4.png">

**After**

<img width="200" alt="after" src="https://user-images.githubusercontent.com/48853629/168625812-91a8f5c2-3ecc-4331-b724-ac9f695de1f7.png">

