### PR TITLE
Fix FinalFormSelect value generic

### DIFF
--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -11,7 +11,7 @@ export interface FinalFormSelectProps<T> extends FieldRenderProps<T, HTMLInputEl
     children?: React.ReactNode;
 }
 
-export const FinalFormSelect = <T extends Record<string, any>>({
+export const FinalFormSelect = <T,>({
     input: { checked, value, name, onChange, onFocus, onBlur, ...restInput },
     meta,
     isAsync = false,


### PR DESCRIPTION
The value generic was incorrectly typed as `T extends Record<string, any>`. This would not work with simple select values such as `string` when rendering the select options using `children`. The `extends Record<string, any>` constraint has been removed from the generic to resolve the issue.