### PR TITLE
Add a `clearable` prop to form components to enable a generic clear-button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ const Providers: React.FunctionComponent = ({ children }) => {
         },
     }
     ```
+-   `FinalFormSearchTextField` no longer has a clear button by default. It can be re-enabled using the `clearable` prop.
 
 ### Migration Guide
 

--- a/packages/admin/admin-color-picker/src/ColorPicker.tsx
+++ b/packages/admin/admin-color-picker/src/ColorPicker.tsx
@@ -1,4 +1,4 @@
-import { InputWithPopper, InputWithPopperComponents, InputWithPopperComponentsProps, InputWithPopperProps } from "@comet/admin";
+import { ClearInputAdornment, InputWithPopper, InputWithPopperComponents, InputWithPopperComponentsProps, InputWithPopperProps } from "@comet/admin";
 import { Box, ComponentsOverrides, InputAdornment, InputBaseProps, Theme } from "@mui/material";
 import { WithStyles, withStyles } from "@mui/styles";
 import * as React from "react";
@@ -22,7 +22,7 @@ export interface ColorPickerPropsComponentsProps extends InputWithPopperComponen
 
 export interface ColorPickerProps extends Omit<InputWithPopperProps, "children" | "onChange" | "value" | "componentsProps" | "components"> {
     value?: string | null;
-    onChange?: (color: string | null) => void;
+    onChange?: (color?: string) => void;
     colorFormat?: "hex" | "rgba";
     colorPalette?: string[];
     hidePicker?: boolean;
@@ -30,6 +30,7 @@ export interface ColorPickerProps extends Omit<InputWithPopperProps, "children" 
     startAdornment?: InputBaseProps["startAdornment"];
     endAdornment?: InputBaseProps["endAdornment"];
     invalidIndicatorCharacter?: string;
+    clearable?: boolean;
     components?: ColorPickerPropsComponents;
     componentsProps?: ColorPickerPropsComponentsProps;
 }
@@ -43,14 +44,16 @@ const ColorPickerPreviewColor = ({ color, ...restProps }: ColorPickerColorPrevie
 };
 
 const ColorPicker = ({
+    classes,
     value,
     colorFormat = "hex",
     hidePicker,
     colorPalette,
     onChange,
     startAdornment,
+    endAdornment,
     onBlur,
-    classes,
+    clearable,
     componentsProps = {},
     components = {},
     ...rest
@@ -119,6 +122,14 @@ const ColorPicker = ({
                         </div>
                     </InputAdornment>
                 )
+            }
+            endAdornment={
+                <>
+                    {clearable && (
+                        <ClearInputAdornment position="end" hasClearableContent={Boolean(value)} onClick={() => onChange && onChange(undefined)} />
+                    )}
+                    {endAdornment}
+                </>
             }
             value={displayValue}
             onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {

--- a/packages/admin/admin-color-picker/src/ColorPicker.tsx
+++ b/packages/admin/admin-color-picker/src/ColorPicker.tsx
@@ -124,12 +124,14 @@ const ColorPicker = ({
                 )
             }
             endAdornment={
-                <>
-                    {clearable && (
+                clearable ? (
+                    <>
                         <ClearInputAdornment position="end" hasClearableContent={Boolean(value)} onClick={() => onChange && onChange(undefined)} />
-                    )}
-                    {endAdornment}
-                </>
+                        {endAdornment}
+                    </>
+                ) : (
+                    endAdornment
+                )
             }
             value={displayValue}
             onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {

--- a/packages/admin/admin-date-time/src/DatePicker.tsx
+++ b/packages/admin/admin-date-time/src/DatePicker.tsx
@@ -37,12 +37,14 @@ export function DatePicker({
             componentsProps={inputWithPopperComponentsProps}
             readOnly
             endAdornment={
-                <>
-                    {clearable && (
+                clearable ? (
+                    <>
                         <ClearInputAdornment position="end" hasClearableContent={Boolean(value)} onClick={() => onChange && onChange(undefined)} />
-                    )}
-                    {endAdornment}
-                </>
+                        {endAdornment}
+                    </>
+                ) : (
+                    endAdornment
+                )
             }
         >
             {(closePopper) => (

--- a/packages/admin/admin-date-time/src/DatePicker.tsx
+++ b/packages/admin/admin-date-time/src/DatePicker.tsx
@@ -1,7 +1,7 @@
 import "react-date-range/dist/styles.css";
 import "react-date-range/dist/theme/default.css";
 
-import { InputWithPopper, InputWithPopperProps } from "@comet/admin";
+import { ClearInputAdornment, InputWithPopper, InputWithPopperProps } from "@comet/admin";
 import * as React from "react";
 import { Calendar, CalendarProps } from "react-date-range";
 import { FormatDateOptions, useIntl } from "react-intl";
@@ -11,10 +11,11 @@ type DatePickerComponentsProps = InputWithPopperProps["componentsProps"] & {
 };
 
 export interface DatePickerProps extends Omit<InputWithPopperProps, "children" | "value" | "onChange" | "componentsProps"> {
-    onChange?: CalendarProps["onChange"];
+    onChange?: (date?: Date) => void;
     value?: Date;
     formatDateOptions?: FormatDateOptions;
     componentsProps?: DatePickerComponentsProps;
+    clearable?: boolean;
 }
 
 export function DatePicker({
@@ -22,6 +23,8 @@ export function DatePicker({
     value,
     componentsProps = {},
     formatDateOptions,
+    endAdornment,
+    clearable,
     ...inputWithPopperProps
 }: DatePickerProps): React.ReactElement {
     const { calendar: calendarProps, ...inputWithPopperComponentsProps } = componentsProps;
@@ -33,6 +36,14 @@ export function DatePicker({
             {...inputWithPopperProps}
             componentsProps={inputWithPopperComponentsProps}
             readOnly
+            endAdornment={
+                <>
+                    {clearable && (
+                        <ClearInputAdornment position="end" hasClearableContent={Boolean(value)} onClick={() => onChange && onChange(undefined)} />
+                    )}
+                    {endAdornment}
+                </>
+            }
         >
             {(closePopper) => (
                 <Calendar

--- a/packages/admin/admin-date-time/src/DateRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/DateRangePicker.tsx
@@ -1,7 +1,7 @@
 import "react-date-range/dist/styles.css";
 import "react-date-range/dist/theme/default.css";
 
-import { InputWithPopper, InputWithPopperProps } from "@comet/admin";
+import { ClearInputAdornment, InputWithPopper, InputWithPopperProps } from "@comet/admin";
 import * as React from "react";
 import { DateRange as ReactDateRange, DateRangeProps as ReactDateRangeProps, Range } from "react-date-range";
 import { FormatDateOptions, useIntl } from "react-intl";
@@ -16,11 +16,12 @@ export type DateRange = {
 };
 
 export interface DateRangePickerProps extends Omit<InputWithPopperProps, "children" | "value" | "onChange" | "componentsProps"> {
-    onChange?: (range: DateRange) => void;
+    onChange?: (range?: DateRange) => void;
     value?: DateRange;
     formatDateOptions?: FormatDateOptions;
     rangeStringSeparator?: string;
     componentsProps?: DateRangePickerComponentsProps;
+    clearable?: boolean;
 }
 
 const useDateRangeTextValue = (range: DateRange | null | undefined, rangeStringSeparator: string, formatDateOptions?: FormatDateOptions): string => {
@@ -67,13 +68,28 @@ export function DateRangePicker({
     componentsProps = {},
     formatDateOptions,
     rangeStringSeparator = " - ",
+    endAdornment,
+    clearable,
     ...inputWithPopperProps
 }: DateRangePickerProps): React.ReactElement {
     const { dateRange: dateRangeProps, ...inputWithPopperComponentsProps } = componentsProps;
     const textValue = useDateRangeTextValue(value, rangeStringSeparator, formatDateOptions);
 
     return (
-        <InputWithPopper value={textValue} {...inputWithPopperProps} componentsProps={inputWithPopperComponentsProps} readOnly>
+        <InputWithPopper
+            value={textValue}
+            {...inputWithPopperProps}
+            componentsProps={inputWithPopperComponentsProps}
+            readOnly
+            endAdornment={
+                <>
+                    {clearable && (
+                        <ClearInputAdornment position="end" hasClearableContent={Boolean(value)} onClick={() => onChange && onChange(undefined)} />
+                    )}
+                    {endAdornment}
+                </>
+            }
+        >
             {(closePopper) => (
                 <ReactDateRange
                     onRangeFocusChange={(newFocusedRange) => {

--- a/packages/admin/admin-date-time/src/DateRangePicker.tsx
+++ b/packages/admin/admin-date-time/src/DateRangePicker.tsx
@@ -82,12 +82,14 @@ export function DateRangePicker({
             componentsProps={inputWithPopperComponentsProps}
             readOnly
             endAdornment={
-                <>
-                    {clearable && (
+                clearable ? (
+                    <>
                         <ClearInputAdornment position="end" hasClearableContent={Boolean(value)} onClick={() => onChange && onChange(undefined)} />
-                    )}
-                    {endAdornment}
-                </>
+                        {endAdornment}
+                    </>
+                ) : (
+                    endAdornment
+                )
             }
         >
             {(closePopper) => (

--- a/packages/admin/admin-stories/src/admin-date-time/DatePicker.tsx
+++ b/packages/admin/admin-stories/src/admin-date-time/DatePicker.tsx
@@ -1,4 +1,4 @@
-import { ClearInputButton, Field } from "@comet/admin";
+import { Field } from "@comet/admin";
 import { FinalFormDatePicker } from "@comet/admin-date-time";
 import { Calendar } from "@comet/admin-icons";
 import { Card, CardContent, InputAdornment } from "@mui/material";
@@ -27,17 +27,13 @@ const Story = () => {
                                 <Field name="dateOne" label="Date" fullWidth component={FinalFormDatePicker} />
                                 <Field
                                     name="dateTwo"
-                                    label="Date with icon and clear-button"
+                                    label="Clearable date with icon"
                                     fullWidth
+                                    clearable
                                     component={FinalFormDatePicker}
                                     startAdornment={
                                         <InputAdornment position="start">
                                             <Calendar />
-                                        </InputAdornment>
-                                    }
-                                    endAdornment={
-                                        <InputAdornment position="end">
-                                            <ClearInputButton onClick={() => change("dateTwo", null)} />
                                         </InputAdornment>
                                     }
                                 />

--- a/packages/admin/admin-stories/src/admin-date-time/DateRangePicker.tsx
+++ b/packages/admin/admin-stories/src/admin-date-time/DateRangePicker.tsx
@@ -1,4 +1,4 @@
-import { ClearInputButton, Field } from "@comet/admin";
+import { Field } from "@comet/admin";
 import { DateRange, FinalFormDateRangePicker } from "@comet/admin-date-time";
 import { Calendar } from "@comet/admin-icons";
 import { Card, CardContent, InputAdornment } from "@mui/material";
@@ -12,9 +12,12 @@ const Story = () => {
         dateRangeTwo?: DateRange | null;
     }
 
+    const today = new Date();
+    const tomorrow = new Date(today.getTime() + 24 * 60 * 60 * 1000);
+
     const initialValues: Partial<Values> = {
         dateRangeOne: null,
-        dateRangeTwo: { start: new Date(), end: new Date() },
+        dateRangeTwo: { start: today, end: tomorrow },
     };
 
     return (
@@ -27,17 +30,13 @@ const Story = () => {
                                 <Field name="dateRangeOne" label="Date range" fullWidth component={FinalFormDateRangePicker} />
                                 <Field
                                     name="dateRangeTwo"
-                                    label="Date range with icon and clear-button"
+                                    label="Clearable date range with icon"
                                     fullWidth
+                                    clearable
                                     component={FinalFormDateRangePicker}
                                     startAdornment={
                                         <InputAdornment position="start">
                                             <Calendar />
-                                        </InputAdornment>
-                                    }
-                                    endAdornment={
-                                        <InputAdornment position="end">
-                                            <ClearInputButton onClick={() => change("dateRangeTwo", null)} />
                                         </InputAdornment>
                                     }
                                 />

--- a/packages/admin/admin-stories/src/docs/components/ClearInputAdornment/ClearInputAdornment.stories.mdx
+++ b/packages/admin/admin-stories/src/docs/components/ClearInputAdornment/ClearInputAdornment.stories.mdx
@@ -11,7 +11,6 @@ It is based on and therefore used the same way as [MuiInputAdornment](https://mu
     <Story id="stories-components-clear-input-adornment-usage--usage" />
 </Canvas>
 
-
 ## Existing `clearable` prop
 
 Many components in Comet Admin already implement the ClearInputAdornment. It can be enabled with the `clearable` prop.

--- a/packages/admin/admin-stories/src/docs/components/ClearInputAdornment/ClearInputAdornment.stories.mdx
+++ b/packages/admin/admin-stories/src/docs/components/ClearInputAdornment/ClearInputAdornment.stories.mdx
@@ -1,0 +1,21 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
+
+<Meta title="Docs/Components/ClearInputAdornment" />
+
+# ClearInputAdornment
+
+`ClearInputAdornment` adds a button to clear the value of an input field.<br />
+It is based on and therefore used the same way as [MuiInputAdornment](https://mui.com/api/input-adornment/).
+
+<Canvas>
+    <Story id="stories-components-clear-input-adornment-usage--usage" />
+</Canvas>
+
+
+## Existing `clearable` prop
+
+Many components in Comet Admin already implement the ClearInputAdornment. It can be enabled with the `clearable` prop.
+
+<Canvas>
+    <Story id="stories-components-clear-input-adornment-existing-clearable-prop--existing-clearable-prop" />
+</Canvas>

--- a/packages/admin/admin-stories/src/docs/components/ClearInputAdornment/stories/ExistingClearableProp.stories.tsx
+++ b/packages/admin/admin-stories/src/docs/components/ClearInputAdornment/stories/ExistingClearableProp.stories.tsx
@@ -1,0 +1,51 @@
+import { Field, FinalFormInput, FinalFormSelect } from "@comet/admin";
+import { FinalFormDatePicker } from "@comet/admin-date-time";
+import { Grid, MenuItem } from "@mui/material";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import { Form } from "react-final-form";
+
+storiesOf("stories/components/Clear Input Adornment/Existing clearable prop", module).add("Existing clearable prop", () => {
+    const selectOptions = [
+        { value: "chocolate", label: "Chocolate" },
+        { value: "strawberry", label: "Strawberry" },
+        { value: "vanilla", label: "Vanilla" },
+    ];
+
+    return (
+        <Form
+            onSubmit={() => {}}
+            initialValues={{
+                text: "Lorem ipsum",
+                select: selectOptions[0].value,
+                date: new Date(),
+            }}
+        >
+            {({ handleSubmit }) => (
+                <form onSubmit={handleSubmit}>
+                    <Grid container spacing={4}>
+                        <Grid item xs={12} md={4}>
+                            <Field component={FinalFormInput} clearable fullWidth name="text" label="FinalFormInput" />
+                        </Grid>
+                        <Grid item xs={12} md={4}>
+                            <Field name="select" label="FinalFormSelect" fullWidth>
+                                {(props) => (
+                                    <FinalFormSelect {...props} clearable>
+                                        {selectOptions.map((option) => (
+                                            <MenuItem value={option.value} key={option.value}>
+                                                {option.label}
+                                            </MenuItem>
+                                        ))}
+                                    </FinalFormSelect>
+                                )}
+                            </Field>
+                        </Grid>
+                        <Grid item xs={12} md={4}>
+                            <Field component={FinalFormDatePicker} clearable fullWidth name="date" label="FinalFormDatePicker" />
+                        </Grid>
+                    </Grid>
+                </form>
+            )}
+        </Form>
+    );
+});

--- a/packages/admin/admin-stories/src/docs/components/ClearInputAdornment/stories/Usage.stories.tsx
+++ b/packages/admin/admin-stories/src/docs/components/ClearInputAdornment/stories/Usage.stories.tsx
@@ -1,0 +1,41 @@
+import { ClearInputAdornment, FieldContainer } from "@comet/admin";
+import { Cut } from "@comet/admin-icons";
+import { Grid, InputBase } from "@mui/material";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+
+storiesOf("stories/components/Clear Input Adornment/Usage", module).add("Usage", () => {
+    const [inputText, setInputText] = React.useState<string>("Lorem ipsum");
+
+    return (
+        <Grid container spacing={4}>
+            <Grid item xs={12} md={6}>
+                <FieldContainer label="Using ClearInputAdornment in an input" fullWidth>
+                    <InputBase
+                        value={inputText}
+                        onChange={(e) => setInputText(e.target.value)}
+                        endAdornment={
+                            <ClearInputAdornment position="end" hasClearableContent={Boolean(inputText)} onClick={() => setInputText("")} />
+                        }
+                    />
+                </FieldContainer>
+            </Grid>
+            <Grid item xs={12} md={6}>
+                <FieldContainer label="Custom icon" fullWidth>
+                    <InputBase
+                        value={inputText}
+                        onChange={(e) => setInputText(e.target.value)}
+                        endAdornment={
+                            <ClearInputAdornment
+                                position="end"
+                                hasClearableContent={Boolean(inputText)}
+                                onClick={() => setInputText("")}
+                                icon={<Cut />}
+                            />
+                        }
+                    />
+                </FieldContainer>
+            </Grid>
+        </Grid>
+    );
+});

--- a/packages/admin/admin-stories/src/docs/components/ColorPicker/stories/ColorPicker.stories.tsx
+++ b/packages/admin/admin-stories/src/docs/components/ColorPicker/stories/ColorPicker.stories.tsx
@@ -5,10 +5,10 @@ import { storiesOf } from "@storybook/react";
 import * as React from "react";
 
 storiesOf("stories/components/Color Picker/Color Picker", module).add("Color Picker", () => {
-    const [colorOne, setColorOne] = React.useState<string | null>("#00ff00");
-    const [colorTwo, setColorTwo] = React.useState<string | null>("rgba(255, 127, 80, 0.75)");
-    const [colorThree, setColorThree] = React.useState<string | null>(null);
-    const [colorFour, setColorFour] = React.useState<string | null>(null);
+    const [colorOne, setColorOne] = React.useState<string | undefined>("#00ff00");
+    const [colorTwo, setColorTwo] = React.useState<string | undefined>("rgba(255, 127, 80, 0.75)");
+    const [colorThree, setColorThree] = React.useState<string | undefined>();
+    const [colorFour, setColorFour] = React.useState<string | undefined>();
 
     return (
         <Grid container spacing={4}>

--- a/packages/admin/admin-stories/src/docs/components/ColorPicker/stories/ColorPickerCustomized.stories.tsx
+++ b/packages/admin/admin-stories/src/docs/components/ColorPicker/stories/ColorPickerCustomized.stories.tsx
@@ -1,14 +1,14 @@
-import { ClearInputButton, FieldContainer } from "@comet/admin";
+import { FieldContainer } from "@comet/admin";
 import { ColorPicker, ColorPickerColorPreviewProps } from "@comet/admin-color-picker";
 import { EmojiEmotions, MoodBad, SentimentDissatisfied } from "@mui/icons-material";
-import { Grid, InputAdornment } from "@mui/material";
+import { Grid } from "@mui/material";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
 
 storiesOf("stories/components/Color Picker/Color Picker Customized", module).add("Color Picker Customized", () => {
-    const [colorOne, setColorOne] = React.useState<string | null>("#00ff00");
-    const [colorTwo, setColorTwo] = React.useState<string | null>("rgba(255, 127, 80, 0.75)");
-    const [colorThree, setColorThree] = React.useState<string | null>(null);
+    const [colorOne, setColorOne] = React.useState<string | undefined>("#00ff00");
+    const [colorTwo, setColorTwo] = React.useState<string | undefined>("rgba(255, 127, 80, 0.75)");
+    const [colorThree, setColorThree] = React.useState<string | undefined>();
 
     const CustomColorPreview = ({ color }: ColorPickerColorPreviewProps): React.ReactElement => {
         return <EmojiEmotions htmlColor={color} sx={{ fontSize: 24 }} />;
@@ -55,18 +55,8 @@ storiesOf("stories/components/Color Picker/Color Picker Customized", module).add
                 </FieldContainer>
             </Grid>
             <Grid item md={4}>
-                <FieldContainer label="Clear Input Button" fullWidth>
-                    <ColorPicker
-                        fullWidth
-                        value={colorTwo}
-                        onChange={setColorTwo}
-                        colorFormat="rgba"
-                        endAdornment={
-                            <InputAdornment position="end">
-                                <ClearInputButton onClick={() => setColorTwo(null)} />
-                            </InputAdornment>
-                        }
-                    />
+                <FieldContainer label="Clearable" fullWidth>
+                    <ColorPicker fullWidth clearable value={colorTwo} onChange={setColorTwo} colorFormat="rgba" />
                 </FieldContainer>
             </Grid>
             <Grid item md={4}>

--- a/packages/admin/admin-stories/src/docs/components/ColorPicker/stories/ColorPickerFinalForm.stories.tsx
+++ b/packages/admin/admin-stories/src/docs/components/ColorPicker/stories/ColorPickerFinalForm.stories.tsx
@@ -8,49 +8,47 @@ import { Form } from "react-final-form";
 storiesOf("stories/components/Color Picker/Color Picker Final Form", module).add("Color Picker Final Form", () => {
     return (
         <Form initialValues={{ color1: "#00ff00", color2: "rgba(255, 127, 80, 0.75)" }} onSubmit={() => {}}>
-            {({ values }) => {
-                return (
-                    <Grid container spacing={4}>
-                        <Grid item md={3}>
-                            <Field name="color1" label="Color-Picker" fullWidth component={FinalFormColorPicker} />
-                        </Grid>
-                        <Grid item md={3}>
-                            <Field name="color2" label="With Alpha Slider" fullWidth component={FinalFormColorPicker} colorFormat="rgba" />
-                        </Grid>
-                        <Grid item md={3}>
-                            <Field
-                                name="color3"
-                                label="With Color Palette"
-                                fullWidth
-                                component={FinalFormColorPicker}
-                                colorPalette={[
-                                    "#f94144",
-                                    "#f3722c",
-                                    "#f8961e",
-                                    "#f9844a",
-                                    "#f9c74f",
-                                    "#90be6d",
-                                    "#43aa8b",
-                                    "#4d908e",
-                                    "#577590",
-                                    "#277da1",
-                                    "red",
-                                    "blue",
-                                    "lime",
-                                    "#29B6F6",
-                                    "#14CC33",
-                                    "#A02710",
-                                    "#226600",
-                                    "#009FBF",
-                                ]}
-                            />
-                        </Grid>
-                        <Grid item md={3}>
-                            <Field name="color4" label="Disabled" fullWidth disabled component={FinalFormColorPicker} />
-                        </Grid>
+            {() => (
+                <Grid container spacing={4}>
+                    <Grid item md={3}>
+                        <Field name="color1" label="Color-Picker" fullWidth component={FinalFormColorPicker} />
                     </Grid>
-                );
-            }}
+                    <Grid item md={3}>
+                        <Field name="color2" label="With Alpha Slider" fullWidth component={FinalFormColorPicker} colorFormat="rgba" />
+                    </Grid>
+                    <Grid item md={3}>
+                        <Field
+                            name="color3"
+                            label="With Color Palette"
+                            fullWidth
+                            component={FinalFormColorPicker}
+                            colorPalette={[
+                                "#f94144",
+                                "#f3722c",
+                                "#f8961e",
+                                "#f9844a",
+                                "#f9c74f",
+                                "#90be6d",
+                                "#43aa8b",
+                                "#4d908e",
+                                "#577590",
+                                "#277da1",
+                                "red",
+                                "blue",
+                                "lime",
+                                "#29B6F6",
+                                "#14CC33",
+                                "#A02710",
+                                "#226600",
+                                "#009FBF",
+                            ]}
+                        />
+                    </Grid>
+                    <Grid item md={3}>
+                        <Field name="color4" label="Disabled" fullWidth disabled component={FinalFormColorPicker} />
+                    </Grid>
+                </Grid>
+            )}
         </Form>
     );
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiAutocomplete.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiAutocomplete.tsx
@@ -1,4 +1,5 @@
 import { Clear } from "@comet/admin-icons";
+import { autocompleteClasses } from "@mui/material";
 import * as React from "react";
 
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
@@ -12,8 +13,20 @@ export const getMuiAutocomplete: GetMuiComponentTheme<"MuiAutocomplete"> = (comp
     },
     styleOverrides: mergeOverrideStyles<"MuiAutocomplete">(component?.styleOverrides, {
         endAdornment: {
-            top: "auto",
+            top: 0,
+            bottom: 0,
             right: spacing(2),
+            display: "flex",
+        },
+        hasPopupIcon: {
+            [`&.${autocompleteClasses.root} .${autocompleteClasses.inputRoot}`]: {
+                paddingRight: 26,
+            },
+        },
+        popupIndicator: {
+            "&:hover": {
+                backgroundColor: "transparent",
+            },
         },
     }),
 });

--- a/packages/admin/admin-theme/src/componentsTheme/MuiInputAdornment.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiInputAdornment.ts
@@ -1,7 +1,7 @@
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
-export const getMuiInputAdornment: GetMuiComponentTheme<"MuiInputAdornment"> = (component) => ({
+export const getMuiInputAdornment: GetMuiComponentTheme<"MuiInputAdornment"> = (component, { spacing }) => ({
     ...component,
     styleOverrides: mergeOverrideStyles(component?.styleOverrides, {
         root: {

--- a/packages/admin/admin-theme/src/componentsTheme/MuiInputBase.ts
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiInputBase.ts
@@ -1,4 +1,4 @@
-import { inputBaseClasses, svgIconClasses } from "@mui/material";
+import { inputBaseClasses } from "@mui/material";
 
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
@@ -11,17 +11,6 @@ export const getMuiInputBase: GetMuiComponentTheme<"MuiInputBase"> = (component,
             borderRadius: 2,
             backgroundColor: "#fff",
 
-            [`& .${svgIconClasses.root}`]: {
-                pointerEvents: "none",
-            },
-            "& [class*='CometAdminClearInputButton-root']": {
-                marginRight: spacing(-2),
-                marginLeft: spacing(-2),
-
-                [`& .${svgIconClasses.root}`]: {
-                    pointerEvents: "auto",
-                },
-            },
             [`&.${inputBaseClasses.focused}`]: {
                 borderColor: palette.primary.main,
             },

--- a/packages/admin/admin-theme/src/componentsTheme/MuiSelect.tsx
+++ b/packages/admin/admin-theme/src/componentsTheme/MuiSelect.tsx
@@ -1,15 +1,8 @@
-import { ChevronDown } from "@comet/admin-icons";
-import * as React from "react";
-
 import { mergeOverrideStyles } from "../utils/mergeOverrideStyles";
 import { GetMuiComponentTheme } from "./getComponentsTheme";
 
 export const getMuiSelect: GetMuiComponentTheme<"MuiSelect"> = (component, { palette }) => ({
     ...component,
-    defaultProps: {
-        IconComponent: ({ className }) => <ChevronDown classes={{ root: className }} />,
-        ...component?.defaultProps,
-    },
     styleOverrides: mergeOverrideStyles<"MuiSelect">(component?.styleOverrides, {
         select: {
             paddingRight: 32,
@@ -17,11 +10,21 @@ export const getMuiSelect: GetMuiComponentTheme<"MuiSelect"> = (component, { pal
             "&:focus": {
                 backgroundColor: "transparent",
             },
+
+            "&:after": {
+                // Expand the clickable area to allow opening by clicking an input adornment, e.g., the arrow-down icon.
+                content: '""',
+                position: "absolute",
+                right: 0,
+                top: 0,
+                bottom: 0,
+                left: 0,
+            },
         },
         icon: {
-            top: "calc(50% - 8px)",
-            right: 12,
-            fontSize: 12,
+            position: "relative",
+            right: 0,
+            order: 1,
             color: palette.grey[900],
         },
     }),

--- a/packages/admin/admin/src/common/ClearInputAdornment.tsx
+++ b/packages/admin/admin/src/common/ClearInputAdornment.tsx
@@ -1,0 +1,90 @@
+import { Clear } from "@comet/admin-icons";
+import {
+    ButtonBase,
+    ComponentsOverrides,
+    Grow,
+    InputAdornment,
+    InputAdornmentClassKey,
+    InputAdornmentProps,
+    selectClasses,
+    Theme,
+} from "@mui/material";
+import { createStyles, WithStyles, withStyles } from "@mui/styles";
+import * as React from "react";
+
+export interface ClearInputAdornmentProps extends InputAdornmentProps {
+    icon?: React.ReactNode;
+    onClick: () => void;
+    hasClearableContent: boolean;
+}
+
+export const ClearAdornment = ({
+    classes,
+    icon = <Clear />,
+    onClick,
+    hasClearableContent,
+    ...restProps
+}: WithStyles<typeof styles> & ClearInputAdornmentProps): React.ReactElement => {
+    const { buttonBase: buttonBaseClassName, ...restClasses } = classes;
+    return (
+        <Grow in={hasClearableContent}>
+            <InputAdornment {...restProps} classes={restClasses}>
+                <ButtonBase className={buttonBaseClassName} tabIndex={-1} onClick={onClick}>
+                    {icon}
+                </ButtonBase>
+            </InputAdornment>
+        </Grow>
+    );
+};
+
+export type ClearInputAdornmentClassKey = InputAdornmentClassKey | "buttonBase";
+
+const styles = ({ palette, spacing }: Theme) => {
+    return createStyles<ClearInputAdornmentClassKey, ClearInputAdornmentProps>({
+        root: {},
+        filled: {},
+        outlined: {},
+        standard: {},
+        positionStart: {
+            "&:last-child": {
+                marginLeft: spacing(-2),
+            },
+        },
+        positionEnd: {
+            "&:last-child": {
+                marginRight: spacing(-2),
+            },
+            [`.${selectClasses.select} ~ &:last-child`]: {
+                // Reset the margin when used inside a MuiSelect, as MuiSelect-icon is moved to the end of the input using `order` and is, therefore, the "real" last-child.
+                marginRight: 0,
+            },
+        },
+        disablePointerEvents: {},
+        hiddenLabel: {},
+        sizeSmall: {},
+        buttonBase: {
+            height: "100%",
+            width: 40,
+            color: palette.action.active,
+        },
+    });
+};
+
+export const ClearInputAdornment = withStyles(styles, { name: "CometAdminClearInputAdornment" })(ClearAdornment);
+
+declare module "@mui/material/styles" {
+    interface ComponentNameToClassKey {
+        CometAdminClearInputAdornment: ClearInputAdornmentClassKey;
+    }
+
+    interface ComponentsPropsList {
+        CometAdminClearInputAdornment: ClearInputAdornmentProps;
+    }
+
+    interface Components {
+        CometAdminClearInputAdornment?: {
+            defaultProps?: ComponentsPropsList["CometAdminClearInputAdornment"];
+            styleOverrides?: ComponentsOverrides<Theme>["CometAdminClearInputAdornment"];
+        };
+    }
+}

--- a/packages/admin/admin/src/common/buttons/clearinput/ClearInputButton.tsx
+++ b/packages/admin/admin/src/common/buttons/clearinput/ClearInputButton.tsx
@@ -1,5 +1,5 @@
 import { Clear } from "@comet/admin-icons";
-import { ButtonBase, ButtonBaseClassKey, ButtonBaseProps, ComponentsOverrides, Theme } from "@mui/material";
+import { ButtonBase, ButtonBaseClassKey, ButtonBaseProps, ComponentsOverrides, inputAdornmentClasses, Theme } from "@mui/material";
 import { createStyles, WithStyles, withStyles } from "@mui/styles";
 import * as React from "react";
 
@@ -8,12 +8,20 @@ export interface ClearInputButtonProps extends ButtonBaseProps {
     icon?: React.ReactNode;
 }
 
-const styles = ({ palette }: Theme) => {
+const styles = ({ palette, spacing }: Theme) => {
     return createStyles<ClearInputButtonClassKey, ClearInputButtonProps>({
         root: {
             height: "100%",
             width: 40,
             color: palette.action.active,
+
+            [`.${inputAdornmentClasses.positionEnd}:last-child &`]: {
+                marginRight: spacing(-2),
+            },
+
+            [`.${inputAdornmentClasses.positionStart}:first-child &`]: {
+                marginLeft: spacing(-2),
+            },
         },
         disabled: {
             color: palette.action.disabled,
@@ -30,6 +38,9 @@ const ClearInputBtn: React.FC<WithStyles<typeof styles> & ClearInputButtonProps>
     );
 };
 
+/**
+ * @deprecated Use `ClearInputAdornment` directly as the InputAdornment instead
+ */
 export const ClearInputButton = withStyles(styles, { name: "CometAdminClearInputButton" })(ClearInputBtn);
 
 declare module "@mui/material/styles" {

--- a/packages/admin/admin/src/form/Autocomplete.tsx
+++ b/packages/admin/admin/src/form/Autocomplete.tsx
@@ -49,11 +49,17 @@ export const FinalFormAutocomplete = <
                     {...params}
                     {...params.InputProps}
                     endAdornment={
-                        <>
-                            {loading && <CircularProgress color="inherit" size={16} />}
-                            {clearable && <ClearInputAdornment position="end" hasClearableContent={Boolean(value)} onClick={() => onChange("")} />}
-                            {params.InputProps.endAdornment}
-                        </>
+                        loading || clearable ? (
+                            <>
+                                {loading && <CircularProgress color="inherit" size={16} />}
+                                {clearable && (
+                                    <ClearInputAdornment position="end" hasClearableContent={Boolean(value)} onClick={() => onChange("")} />
+                                )}
+                                {params.InputProps.endAdornment}
+                            </>
+                        ) : (
+                            params.InputProps.endAdornment
+                        )
                     }
                 />
             )}

--- a/packages/admin/admin/src/form/Autocomplete.tsx
+++ b/packages/admin/admin/src/form/Autocomplete.tsx
@@ -1,8 +1,21 @@
+import { ChevronDown } from "@comet/admin-icons";
 import { Autocomplete, AutocompleteProps, AutocompleteRenderInputParams, CircularProgress, InputBase } from "@mui/material";
 import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
 
+import { ClearInputAdornment } from "../common/ClearInputAdornment";
 import { AsyncOptionsProps } from "../hooks/useAsyncOptionsProps";
+
+export type FinalFormAutocompleteProps<
+    T extends Record<string, any>,
+    Multiple extends boolean | undefined,
+    DisableClearable extends boolean | undefined,
+    FreeSolo extends boolean | undefined,
+> = FieldRenderProps<T, HTMLInputElement | HTMLTextAreaElement> &
+    Partial<AsyncOptionsProps<T>> &
+    Omit<AutocompleteProps<T, Multiple, DisableClearable, FreeSolo>, "renderInput"> & {
+        clearable?: boolean;
+    };
 
 export const FinalFormAutocomplete = <
     T extends Record<string, any>,
@@ -13,12 +26,14 @@ export const FinalFormAutocomplete = <
     input: { onChange, value, ...restInput },
     loading = false,
     isAsync = false,
+    clearable,
+    popupIcon = <ChevronDown />,
     ...rest
-}: FieldRenderProps<T, HTMLInputElement | HTMLTextAreaElement> &
-    Partial<AsyncOptionsProps<T>> &
-    Omit<AutocompleteProps<T, Multiple, DisableClearable, FreeSolo>, "renderInput">) => {
+}: FinalFormAutocompleteProps<T, Multiple, DisableClearable, FreeSolo>) => {
     return (
         <Autocomplete
+            popupIcon={popupIcon}
+            disableClearable
             isOptionEqualToValue={(option: T, value: T) => {
                 if (!value) return false;
                 return option === value;
@@ -34,10 +49,11 @@ export const FinalFormAutocomplete = <
                     {...params}
                     {...params.InputProps}
                     endAdornment={
-                        <React.Fragment>
-                            {loading ? <CircularProgress color="inherit" size={16} /> : null}
+                        <>
+                            {loading && <CircularProgress color="inherit" size={16} />}
+                            {clearable && <ClearInputAdornment position="end" hasClearableContent={Boolean(value)} onClick={() => onChange("")} />}
                             {params.InputProps.endAdornment}
-                        </React.Fragment>
+                        </>
                     }
                 />
             )}

--- a/packages/admin/admin/src/form/FinalFormInput.tsx
+++ b/packages/admin/admin/src/form/FinalFormInput.tsx
@@ -15,12 +15,14 @@ export function FinalFormInput({ meta, input, innerRef, endAdornment, clearable,
             {...input}
             {...props}
             endAdornment={
-                <>
-                    {clearable && (
+                clearable ? (
+                    <>
                         <ClearInputAdornment position="end" hasClearableContent={Boolean(input.value)} onClick={() => input.onChange("")} />
-                    )}
-                    {endAdornment}
-                </>
+                        {endAdornment}
+                    </>
+                ) : (
+                    endAdornment
+                )
             }
         />
     );

--- a/packages/admin/admin/src/form/FinalFormInput.tsx
+++ b/packages/admin/admin/src/form/FinalFormInput.tsx
@@ -2,8 +2,26 @@ import { InputBase, InputBaseProps } from "@mui/material";
 import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
 
-export type FinalFormInputProps = InputBaseProps & FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement>;
+import { ClearInputAdornment } from "../common/ClearInputAdornment";
 
-export function FinalFormInput({ meta, input, innerRef, ...props }: FinalFormInputProps): React.ReactElement {
-    return <InputBase {...input} {...props} />;
+export type FinalFormInputProps = InputBaseProps &
+    FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement> & {
+        clearable?: boolean;
+    };
+
+export function FinalFormInput({ meta, input, innerRef, endAdornment, clearable, ...props }: FinalFormInputProps): React.ReactElement {
+    return (
+        <InputBase
+            {...input}
+            {...props}
+            endAdornment={
+                <>
+                    {clearable && (
+                        <ClearInputAdornment position="end" hasClearableContent={Boolean(input.value)} onClick={() => input.onChange("")} />
+                    )}
+                    {endAdornment}
+                </>
+            }
+        />
+    );
 }

--- a/packages/admin/admin/src/form/FinalFormSearchTextField.tsx
+++ b/packages/admin/admin/src/form/FinalFormSearchTextField.tsx
@@ -1,26 +1,24 @@
 import { Search } from "@comet/admin-icons";
-import { InputAdornment, InputAdornmentProps } from "@mui/material";
-import { styled } from "@mui/material/styles";
+import { InputAdornment } from "@mui/material";
 import { withStyles } from "@mui/styles";
 import * as React from "react";
 import { useIntl } from "react-intl";
 
-import { ClearInputButton } from "..";
+import { ClearInputAdornment } from "../common/ClearInputAdornment";
 import { FinalFormInput, FinalFormInputProps } from "./FinalFormInput";
-
-interface ClearInputAdornmentProps extends InputAdornmentProps {
-    $hidden: boolean;
-}
-
-const ClearInputAdornment = styled(InputAdornment)<ClearInputAdornmentProps>`
-    visibility: ${({ $hidden }) => ($hidden ? "hidden" : "initial")};
-`;
 
 export interface FinalFormSearchTextFieldProps extends FinalFormInputProps {
     icon?: React.ReactNode;
+    clearable?: boolean;
 }
 
-function SearchTextField({ icon = <Search />, placeholder, endAdornment, ...restProps }: FinalFormSearchTextFieldProps): React.ReactElement {
+function SearchTextField({
+    icon = <Search />,
+    placeholder,
+    endAdornment,
+    clearable,
+    ...restProps
+}: FinalFormSearchTextFieldProps): React.ReactElement {
     const intl = useIntl();
 
     return (
@@ -29,15 +27,16 @@ function SearchTextField({ icon = <Search />, placeholder, endAdornment, ...rest
             placeholder={placeholder ?? intl.formatMessage({ id: "comet.finalformsearchtextfield.default.placeholder", defaultMessage: "Search" })}
             startAdornment={<InputAdornment position="start">{icon}</InputAdornment>}
             endAdornment={
-                endAdornment ?? (
-                    <ClearInputAdornment position="end" $hidden={restProps.input.value.length === 0}>
-                        <ClearInputButton
-                            onClick={() => {
-                                restProps.input.onChange("");
-                            }}
+                <>
+                    {endAdornment}
+                    {clearable && (
+                        <ClearInputAdornment
+                            position="end"
+                            hasClearableContent={Boolean(restProps.input.value)}
+                            onClick={() => restProps.input.onChange("")}
                         />
-                    </ClearInputAdornment>
-                )
+                    )}
+                </>
             }
         />
     );

--- a/packages/admin/admin/src/form/FinalFormSearchTextField.tsx
+++ b/packages/admin/admin/src/form/FinalFormSearchTextField.tsx
@@ -27,16 +27,18 @@ function SearchTextField({
             placeholder={placeholder ?? intl.formatMessage({ id: "comet.finalformsearchtextfield.default.placeholder", defaultMessage: "Search" })}
             startAdornment={<InputAdornment position="start">{icon}</InputAdornment>}
             endAdornment={
-                <>
-                    {endAdornment}
-                    {clearable && (
+                clearable ? (
+                    <>
                         <ClearInputAdornment
                             position="end"
                             hasClearableContent={Boolean(restProps.input.value)}
                             onClick={() => restProps.input.onChange("")}
                         />
-                    )}
-                </>
+                        {endAdornment}
+                    </>
+                ) : (
+                    endAdornment
+                )
             }
         />
     );

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -35,11 +35,13 @@ export const FinalFormSelect = <T,>({
     clearable,
     ...rest
 }: FinalFormSelectProps<T> & Partial<AsyncOptionsProps<T>> & Omit<SelectProps, "input">) => {
-    const selectEndAdornment = (
+    const selectEndAdornment = clearable ? (
         <>
-            {clearable && <ClearInputAdornment position="end" hasClearableContent={Boolean(value)} onClick={() => onChange(undefined)} />}
+            <ClearInputAdornment position="end" hasClearableContent={Boolean(value)} onClick={() => onChange(undefined)} />
             {endAdornment}
         </>
+    ) : (
+        endAdornment
     );
 
     if (children) {

--- a/packages/admin/admin/src/form/FinalFormSelect.tsx
+++ b/packages/admin/admin/src/form/FinalFormSelect.tsx
@@ -2,6 +2,7 @@ import { CircularProgress, MenuItem, SelectProps } from "@mui/material";
 import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
 
+import { ClearInputAdornment } from "../common/ClearInputAdornment";
 import { AsyncOptionsProps } from "../hooks/useAsyncOptionsProps";
 import { Select } from "./Select";
 
@@ -9,6 +10,7 @@ export interface FinalFormSelectProps<T> extends FieldRenderProps<T, HTMLInputEl
     getOptionSelected?: (option: T, value: T) => boolean;
     getOptionLabel?: (option: T) => string;
     children?: React.ReactNode;
+    clearable?: boolean;
 }
 
 export const FinalFormSelect = <T,>({
@@ -29,11 +31,20 @@ export const FinalFormSelect = <T,>({
         return option === value;
     },
     children,
+    endAdornment,
+    clearable,
     ...rest
 }: FinalFormSelectProps<T> & Partial<AsyncOptionsProps<T>> & Omit<SelectProps, "input">) => {
+    const selectEndAdornment = (
+        <>
+            {clearable && <ClearInputAdornment position="end" hasClearableContent={Boolean(value)} onClick={() => onChange(undefined)} />}
+            {endAdornment}
+        </>
+    );
+
     if (children) {
         return (
-            <Select {...rest} name={name} onChange={onChange} value={value} onFocus={onFocus} onBlur={onBlur}>
+            <Select {...rest} endAdornment={selectEndAdornment} name={name} onChange={onChange} value={value} onFocus={onFocus} onBlur={onBlur}>
                 {children}
             </Select>
         );
@@ -44,7 +55,7 @@ export const FinalFormSelect = <T,>({
     }
 
     return (
-        <Select {...rest} name={name} onChange={onChange} value={value} onFocus={onFocus} onBlur={onBlur}>
+        <Select {...rest} endAdornment={selectEndAdornment} name={name} onChange={onChange} value={value} onFocus={onFocus} onBlur={onBlur}>
             {options.length === 0 && (loading || value) && (
                 <MenuItem value={value as any} key={JSON.stringify(value)}>
                     {loading ? <CircularProgress size="20px" style={{ marginLeft: "16px" }} /> : getOptionLabel(value)}

--- a/packages/admin/admin/src/form/Select.tsx
+++ b/packages/admin/admin/src/form/Select.tsx
@@ -1,4 +1,17 @@
-import { InputBase, Select as MuiSelect, SelectProps } from "@mui/material";
+import { ChevronDown } from "@comet/admin-icons";
+import { InputAdornment, InputBase, Select as MuiSelect, SelectProps } from "@mui/material";
 import * as React from "react";
 
-export const Select: React.FunctionComponent<SelectProps> = (props) => <MuiSelect input={<InputBase />} {...props} />;
+type IconProps = {
+    className: string;
+};
+
+const Icon = ({ className }: IconProps) => (
+    <InputAdornment position="end" className={className}>
+        <ChevronDown />
+    </InputAdornment>
+);
+
+export const Select = ({ IconComponent = Icon, ...restProps }: SelectProps): React.ReactElement => {
+    return <MuiSelect IconComponent={IconComponent} input={<InputBase />} {...restProps} />;
+};

--- a/packages/admin/admin/src/index.ts
+++ b/packages/admin/admin/src/index.ts
@@ -21,6 +21,7 @@ export { SaveButtonClassKey } from "./common/buttons/save/SaveButton.styles";
 export { SplitButton, SplitButtonProps } from "./common/buttons/split/SplitButton";
 export { SplitButtonContext, SplitButtonContextOptions } from "./common/buttons/split/SplitButtonContext";
 export { useSplitButtonContext } from "./common/buttons/split/useSplitButtonContext";
+export { ClearInputAdornment, ClearInputAdornmentProps } from "./common/ClearInputAdornment";
 export { CometLogo } from "./common/CometLogo";
 export { HoverActions, HoverActionsClassKey, HoverActionsProps } from "./common/HoverActions";
 export { ToolbarActions, ToolbarActionsClassKey } from "./common/toolbar/actions/ToolbarActions";
@@ -53,7 +54,7 @@ export {
     FinalFormSaveCancelButtonsLegacyProps,
 } from "./FinalFormSaveCancelButtonsLegacy";
 export { FinalFormSaveSplitButton } from "./FinalFormSaveSplitButton";
-export { FinalFormAutocomplete } from "./form/Autocomplete";
+export { FinalFormAutocomplete, FinalFormAutocompleteProps } from "./form/Autocomplete";
 export { FinalFormCheckbox, FinalFormCheckboxProps } from "./form/Checkbox";
 export { Field, FieldProps } from "./form/Field";
 export { FieldContainer, FieldContainerClassKey, FieldContainerComponent, FieldContainerProps } from "./form/FieldContainer";


### PR DESCRIPTION
- Create a `ClearInputAdornment` component to use directly as the InputAdornment instead of using the now deprecated `ClearButton`.  
- Make the `endAdornment` & dropdown-icon look the same for `Select` and `Autocomplete`.