### PR TITLE
Fix preview style for block preview

### DIFF
--- a/packages/site/site-cms/src/iframebridge/Preview.sc.ts
+++ b/packages/site/site-cms/src/iframebridge/Preview.sc.ts
@@ -1,7 +1,6 @@
 import styled, { css } from "styled-components";
 
 export const Root = styled.div<ISelectionStyleProps>`
-    display: inline-block;
     position: relative;
 `;
 


### PR DESCRIPTION
If you want to refer to a property (e.g. the width) of an element that is above the overlay with a percentage value, the overlay must be a block element (no inline-block element). If the element below the overlay is a block element, another element with the property display: inline-block (or better: display: inline-flex) must be inserted between the outermost element and the overlay.