### PR TITLE
Minor releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,6 @@
 name: CI
 
 on:
-    push:
-        tags:
-            - "[0-9]+.[0-9]+.[0-9]+"
-        branches:
-            - main
-            - next
     pull_request:
         branches:
             - main
@@ -19,6 +13,12 @@ jobs:
             - run: echo "${{ github.actor }}"
 
             - uses: actions/checkout@v3
+              with:
+                  token: ${{ secrets.GH_TOKEN }}
+
+            - run: |
+                  git config user.name github-actions
+                  git config user.email github-actions@github.com
 
             - name: Use Node.js 14.x
               uses: actions/setup-node@v3
@@ -62,7 +62,6 @@ jobs:
                   git clone https://github.com/vivid-planet/comet-admin-lang.git
                   cp -r lang/* comet-admin-lang/
                   cd comet-admin-lang
-                  git config user.email "vivid-planet-bot@vivid-planet.com"
                   git add .
                   if [[ `git status --porcelain` ]]; then git commit -m "add translatable strings for ${{ github.sha }}" && git remote rm origin && git remote add origin https://vivid-planet-bot:${{ secrets.GH_TOKEN }}@github.com/vivid-planet/comet-admin-lang.git && git push --set-upstream origin master; fi
 
@@ -75,8 +74,12 @@ jobs:
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-            - name: Publish stable release
-              if: ${{ github.ref_type == 'tag' }}
-              run: yarn publish:release ${{ github.ref_name }} --yes
+            - name: Publish stable minor release
+              if: |
+                  github.event.label.name != 'skip-release' &&
+                  github.base_ref == 'main' &&
+                  github.event.pull_request.merged == true
+              run: yarn publish:release minor --yes
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,12 @@ jobs:
                   git add .
                   if [[ `git status --porcelain` ]]; then git commit -m "add translatable strings for ${{ github.sha }}" && git remote rm origin && git remote add origin https://vivid-planet-bot:${{ secrets.GH_TOKEN }}@github.com/vivid-planet/comet-admin-lang.git && git push --set-upstream origin master; fi
 
-            - name: Publish Canary release
-              if: ${{ github.ref_name == 'main' || github.ref_name == 'next' }}
-              run: yarn publish:release --canary --preid=canary.${{ github.run_number }} --dist-tag=canary --yes
+            - name: Publish premajor canary release
+              if: |
+                  github.event.label.name != 'skip-release' &&
+                  github.base_ref == 'next' &&
+                  github.event.pull_request.merged == true
+              run: yarn publish:release premajor --no-push --no-git-tag-version --canary --preid=canary.${{ github.run_number }} --dist-tag=canary --yes
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "clean": "lerna run clean --stream --parallel",
         "start": "pm2 start ecosystem.config.js",
         "build": "lerna run build --concurrency=1 --stream",
-        "publish:release": "lerna publish --force-publish --no-push --no-git-tag-version --no-private",
+        "publish:release": "lerna publish --force-publish --no-private",
         "storybook": "yarn workspace comet-admin-stories storybook",
         "lint": "lerna run lint --concurrency=1 --stream",
         "lint:eslint": "lerna run lint:eslint --concurrency=1 --stream",


### PR DESCRIPTION
new release behavior:

- disabled tag pipelines not needed anymore
- canary premajor-releases only for next branch
- main branch releases now every time new minor release and commits package version updates
- release pipelines can be skipped with "skip-release" label

works in only for >= v3 when github workflows were merged in main