### PR TITLE
Refactor/Fix RouterTabs

### DIFF
--- a/packages/admin/src/tabs/RouterTabs.tsx
+++ b/packages/admin/src/tabs/RouterTabs.tsx
@@ -11,7 +11,7 @@ import { useStackSwitchApi } from "../stack/Switch";
 import { RouterTabsClassKey, styles } from "./RouterTabs.styles";
 
 function deduplicateSlashesInUrl(url: string) {
-    return url.replace(/\/+/, "/");
+    return url.replace(/\/+/g, "/");
 }
 
 interface TabProps extends MuiTabProps {

--- a/packages/admin/src/tabs/RouterTabs.tsx
+++ b/packages/admin/src/tabs/RouterTabs.tsx
@@ -103,17 +103,18 @@ function RouterTabsComponent({
                     return React.isValidElement<TabProps>(child) ? (
                         <Route path={`${match.url}${child.props.path}`}>
                             {({ match }) => {
-                                if (!match && !child.props.forceRender) {
-                                    return null;
-                                }
                                 if (match && stackApi && stackSwitchApi) {
                                     return (
                                         <StackBreadcrumb url={`${match.url}${child.props.path}`} title={child.props.label} invisible={true}>
                                             <div className={classes.content}>{child.props.children}</div>
                                         </StackBreadcrumb>
                                     );
-                                } else {
+                                } else if (match) {
+                                    return <div className={classes.content}>{child.props.children}</div>;
+                                } else if (!match && child.props.forceRender) {
                                     return <div className={`${classes.content} ${classes.contentHidden}`}>{child.props.children}</div>;
+                                } else {
+                                    return null;
                                 }
                             }}
                         </Route>

--- a/packages/admin/src/tabs/RouterTabs.tsx
+++ b/packages/admin/src/tabs/RouterTabs.tsx
@@ -38,7 +38,6 @@ function RouterTabsComponent({
 }: Props & WithStyles<typeof styles>) {
     const stackApi = useStackApi();
     const stackSwitchApi = useStackSwitchApi();
-    const [shouldShowTabBar, setShouldShowTabBar] = React.useState(true);
 
     const childrenArr = React.Children.toArray(children);
 
@@ -71,15 +70,14 @@ function RouterTabsComponent({
         rearrangedChildren.push(defaultPathChild);
     }
 
-    React.useEffect(() => {
-        if (stackApi && stackSwitchApi) {
-            // When inside a Stack show only the last TabBar
-            const ownSwitchIndex = stackSwitchApi.id ? stackApi.switches.findIndex((i) => i.id === stackSwitchApi.id) : -1;
-            const nextSwitchShowsInitialPage = stackApi.switches[ownSwitchIndex + 1] && stackApi.switches[ownSwitchIndex + 1].isInitialPageActive;
+    let shouldShowTabBar = true;
+    if (stackApi && stackSwitchApi) {
+        // When inside a Stack show only the last TabBar
+        const ownSwitchIndex = stackSwitchApi.id ? stackApi.switches.findIndex((i) => i.id === stackSwitchApi.id) : -1;
+        const nextSwitchShowsInitialPage = stackApi.switches[ownSwitchIndex + 1] && stackApi.switches[ownSwitchIndex + 1].isInitialPageActive;
 
-            setShouldShowTabBar(ownSwitchIndex === stackApi.switches.length - (nextSwitchShowsInitialPage ? 2 : 1));
-        }
-    }, [stackApi, stackSwitchApi]);
+        shouldShowTabBar = ownSwitchIndex === stackApi.switches.length - (nextSwitchShowsInitialPage ? 2 : 1);
+    }
 
     return (
         <div className={classes.root}>

--- a/packages/admin/src/tabs/RouterTabs.tsx
+++ b/packages/admin/src/tabs/RouterTabs.tsx
@@ -10,6 +10,10 @@ import { StackBreadcrumb } from "../stack/Breadcrumb";
 import { useStackSwitchApi } from "../stack/Switch";
 import { RouterTabsClassKey, styles } from "./RouterTabs.styles";
 
+function deduplicateSlashesInUrl(url: string) {
+    return url.replace(/\/+/, "/");
+}
+
 interface TabProps extends MuiTabProps {
     path: string;
     label: React.ReactNode;
@@ -42,7 +46,7 @@ function RouterTabsComponent({
         const paths = childrenArr.map((child) => {
             return React.isValidElement<TabProps>(child) ? child.props.path : null;
         });
-        history.push(match.url + paths[value]);
+        history.push(deduplicateSlashesInUrl(match.url + paths[value]));
     };
 
     const paths = childrenArr.map((child) => {
@@ -80,7 +84,7 @@ function RouterTabsComponent({
     return (
         <div className={classes.root}>
             {shouldShowTabBar && (
-                <Route path={`${match.url}/:tab`}>
+                <Route path={deduplicateSlashesInUrl(`${match.url}/:tab`)}>
                     {({ match }) => {
                         const routePath = match ? `/${match.params.tab}` : "";
                         const value = paths.includes(routePath) ? paths.indexOf(routePath) : defaultPathIndex;
@@ -101,11 +105,15 @@ function RouterTabsComponent({
             <Switch>
                 {React.Children.map(rearrangedChildren, (child) => {
                     return React.isValidElement<TabProps>(child) ? (
-                        <Route path={`${match.url}${child.props.path}`}>
+                        <Route path={deduplicateSlashesInUrl(`${match.url}/${child.props.path}`)}>
                             {({ match }) => {
                                 if (match && stackApi && stackSwitchApi) {
                                     return (
-                                        <StackBreadcrumb url={`${match.url}${child.props.path}`} title={child.props.label} invisible={true}>
+                                        <StackBreadcrumb
+                                            url={deduplicateSlashesInUrl(`${match.url}/${child.props.path}`)}
+                                            title={child.props.label}
+                                            invisible={true}
+                                        >
                                             <div className={classes.content}>{child.props.children}</div>
                                         </StackBreadcrumb>
                                     );


### PR DESCRIPTION
Refactor:

- use hooks in RouterTabs (`useStackApi()`, `useStackSwitchApi()`) instead of context consumers (`<StackApiContext.Consumer>`, `<StackSwitchApiContext.Consumer>`)

Bug Fixes:

- make `RouterTabs` usable outside `Stack` (previously this caused an error because `StackBreadcrumb` was always rendered)
- fix routes in RouterTabs (previously double-slashes were used resulting in routes like`//tab2` or `//tab2//sub-tab3`)
