### PR TITLE
Fix RouterTabs forceRender

### DIFF
--- a/packages/admin-stories/src/docs/components/RouterTabs/stories/NestedStackSwitchWithRouterTabs.stories.tsx
+++ b/packages/admin-stories/src/docs/components/RouterTabs/stories/NestedStackSwitchWithRouterTabs.stories.tsx
@@ -1,0 +1,67 @@
+import { RouterTab, RouterTabs, Stack, StackBreadcrumbs, StackPage, StackSwitch } from "@comet/admin";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import { useLocation } from "react-router";
+
+import { storyRouterDecorator } from "../../../../story-router.decorator";
+
+storiesOf("stories/components/Tabs/Nested StackSwitch with RouterTabs", module)
+    .addDecorator(storyRouterDecorator())
+    .add("Nested StackSwitch with RouterTabs", () => {
+        const location = useLocation();
+
+        return (
+            <div>
+                <p>Location: {location.pathname}</p>
+                <Stack topLevelTitle="Root Stack">
+                    <StackBreadcrumbs />
+                    <RouterTabs>
+                        <RouterTab label="Page 1" path="">
+                            <StackSwitch>
+                                <StackPage name="table">
+                                    <RouterTabs>
+                                        <RouterTab label="Page 3" path="">
+                                            Page 3
+                                        </RouterTab>
+                                        <RouterTab label="Page 4" path="/page4">
+                                            Now the first level of RouterTabs (Page 1 and 2) disappeared
+                                            <StackSwitch>
+                                                <StackPage name="table">
+                                                    <RouterTabs>
+                                                        <RouterTab label="Page 5" path="">
+                                                            Page 5
+                                                        </RouterTab>
+                                                        <RouterTab label="Page 6" path="/page6">
+                                                            Now the second level of RouterTabs (Page 3 and 4) also disappeared
+                                                            <StackSwitch>
+                                                                <StackPage name="table">
+                                                                    <RouterTabs>
+                                                                        <RouterTab label="Page 7" path="">
+                                                                            Page 7
+                                                                        </RouterTab>
+                                                                        <RouterTab label="Page 8" path="/page8">
+                                                                            Page 8
+                                                                        </RouterTab>
+                                                                    </RouterTabs>
+                                                                </StackPage>
+                                                                <StackPage name="stackpage-4">StackPage 4</StackPage>
+                                                            </StackSwitch>
+                                                        </RouterTab>
+                                                    </RouterTabs>
+                                                </StackPage>
+                                                <StackPage name="stackpage-3">StackPage 3</StackPage>
+                                            </StackSwitch>
+                                        </RouterTab>
+                                    </RouterTabs>
+                                </StackPage>
+                                <StackPage name="stackpage-2">StackPage 2</StackPage>
+                            </StackSwitch>
+                        </RouterTab>
+                        <RouterTab label="Page 2" path="/page2">
+                            Page 2
+                        </RouterTab>
+                    </RouterTabs>
+                </Stack>
+            </div>
+        );
+    });

--- a/packages/admin-stories/src/docs/components/RouterTabs/stories/RouterTabsForceRender.stories.tsx
+++ b/packages/admin-stories/src/docs/components/RouterTabs/stories/RouterTabsForceRender.stories.tsx
@@ -1,0 +1,180 @@
+import {
+    Field,
+    FinalForm,
+    FinalFormInput,
+    RouterTab,
+    RouterTabs,
+    SaveButton,
+    SplitButton,
+    Toolbar,
+    ToolbarActions,
+    ToolbarBackButton,
+    ToolbarFillSpace,
+} from "@comet/admin";
+import { Card, CardContent } from "@material-ui/core";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import { useLocation } from "react-router";
+
+import { apolloStoryDecorator } from "../../../../apollo-story.decorator";
+import { storyRouterDecorator } from "../../../../story-router.decorator";
+
+storiesOf("stories/components/Tabs/RouterTabs forceRender", module)
+    .addDecorator(storyRouterDecorator())
+    .addDecorator(apolloStoryDecorator())
+    .add("RouterTabs with forceRender", () => {
+        const location = useLocation();
+
+        return (
+            <div>
+                <p>Location: {location.pathname}</p>
+                <FinalForm
+                    mode="edit"
+                    onSubmit={(values: any) => {
+                        alert(JSON.stringify(values));
+                    }}
+                    initialValues={{
+                        foo: "foo",
+                        bar: "bar",
+                    }}
+                >
+                    {({ pristine, dirty, hasValidationErrors, submitting, hasSubmitErrors, handleSubmit, ...formVars }) => {
+                        return (
+                            <>
+                                Pristine: {String(pristine)} <br />
+                                Dirty: {String(dirty)}
+                                <Toolbar>
+                                    <ToolbarBackButton />
+                                    <ToolbarFillSpace />
+                                    <ToolbarActions>
+                                        <SplitButton
+                                            disabled={pristine || hasValidationErrors || submitting}
+                                            localStorageKey={"routertabs-with-forms-save"}
+                                        >
+                                            <SaveButton
+                                                color={"primary"}
+                                                variant={"contained"}
+                                                saving={submitting}
+                                                hasErrors={hasSubmitErrors}
+                                                type="button"
+                                                onClick={async () => {
+                                                    handleSubmit();
+                                                }}
+                                            >
+                                                Save
+                                            </SaveButton>
+                                            <SaveButton
+                                                color={"primary"}
+                                                variant={"contained"}
+                                                saving={submitting}
+                                                hasErrors={hasSubmitErrors}
+                                                onClick={async () => {
+                                                    handleSubmit();
+                                                }}
+                                            >
+                                                Save and go back
+                                            </SaveButton>
+                                        </SplitButton>
+                                    </ToolbarActions>
+                                </Toolbar>
+                                <RouterTabs>
+                                    <RouterTab label="Form 1" path="" forceRender>
+                                        <Card variant="outlined">
+                                            <CardContent>
+                                                <Field label="Foo" name="foo" component={FinalFormInput} />
+                                            </CardContent>
+                                        </Card>
+                                    </RouterTab>
+                                    <RouterTab label="Form 2" path="/form2" forceRender>
+                                        <Card variant="outlined">
+                                            <CardContent>
+                                                <Field label="Bar" name="bar" component={FinalFormInput} />
+                                            </CardContent>
+                                        </Card>
+                                    </RouterTab>
+                                </RouterTabs>
+                            </>
+                        );
+                    }}
+                </FinalForm>
+            </div>
+        );
+    })
+    .add("RouterTabs without forceRender", () => {
+        const location = useLocation();
+
+        return (
+            <div>
+                <p>Location: {location.pathname}</p>
+                <FinalForm
+                    mode="edit"
+                    onSubmit={(values: any) => {
+                        alert(JSON.stringify(values));
+                    }}
+                    initialValues={{
+                        foo: "foo",
+                        bar: "bar",
+                    }}
+                >
+                    {({ pristine, dirty, hasValidationErrors, submitting, hasSubmitErrors, handleSubmit, ...formVars }) => {
+                        return (
+                            <>
+                                Pristine: {String(pristine)} <br />
+                                Dirty: {String(dirty)}
+                                <Toolbar>
+                                    <ToolbarBackButton />
+                                    <ToolbarFillSpace />
+                                    <ToolbarActions>
+                                        <SplitButton
+                                            disabled={pristine || hasValidationErrors || submitting}
+                                            localStorageKey={"routertabs-with-forms-save"}
+                                        >
+                                            <SaveButton
+                                                color={"primary"}
+                                                variant={"contained"}
+                                                saving={submitting}
+                                                hasErrors={hasSubmitErrors}
+                                                type="button"
+                                                onClick={async () => {
+                                                    handleSubmit();
+                                                }}
+                                            >
+                                                Save
+                                            </SaveButton>
+                                            <SaveButton
+                                                color={"primary"}
+                                                variant={"contained"}
+                                                saving={submitting}
+                                                hasErrors={hasSubmitErrors}
+                                                onClick={async () => {
+                                                    handleSubmit();
+                                                }}
+                                            >
+                                                Save and go back
+                                            </SaveButton>
+                                        </SplitButton>
+                                    </ToolbarActions>
+                                </Toolbar>
+                                <RouterTabs>
+                                    <RouterTab label="Form 1" path="">
+                                        <Card variant="outlined">
+                                            <CardContent>
+                                                <Field label="Foo" name="foo" component={FinalFormInput} />
+                                            </CardContent>
+                                        </Card>
+                                    </RouterTab>
+                                    <RouterTab label="Form 2" path="/form2">
+                                        <Card variant="outlined">
+                                            <CardContent>
+                                                <Field label="Bar" name="bar" component={FinalFormInput} />
+                                            </CardContent>
+                                        </Card>
+                                    </RouterTab>
+                                </RouterTabs>
+                            </>
+                        );
+                    }}
+                </FinalForm>
+            </div>
+        );
+    });

--- a/packages/admin-stories/src/docs/components/RouterTabs/stories/RouterTabsForceRender.stories.tsx
+++ b/packages/admin-stories/src/docs/components/RouterTabs/stories/RouterTabsForceRender.stories.tsx
@@ -22,7 +22,7 @@ import { storyRouterDecorator } from "../../../../story-router.decorator";
 storiesOf("stories/components/Tabs/RouterTabs forceRender", module)
     .addDecorator(storyRouterDecorator())
     .addDecorator(apolloStoryDecorator())
-    .add("RouterTabs with forceRender", () => {
+    .add("RouterTabs with Form and forceRender", () => {
         const location = useLocation();
 
         return (
@@ -100,7 +100,7 @@ storiesOf("stories/components/Tabs/RouterTabs forceRender", module)
             </div>
         );
     })
-    .add("RouterTabs without forceRender", () => {
+    .add("RouterTabs with Form without forceRender", () => {
         const location = useLocation();
 
         return (

--- a/packages/admin-stories/src/story-router.decorator.tsx
+++ b/packages/admin-stories/src/story-router.decorator.tsx
@@ -1,6 +1,6 @@
 import { RouterMemoryRouter } from "@comet/admin";
 import { action } from "@storybook/addon-actions";
-import { StoryContext, StoryFn } from "@storybook/addons";
+import { StoryContext } from "@storybook/addons";
 import { Action, History, UnregisterCallback } from "history";
 import * as React from "react";
 import { MemoryRouterProps, Route, RouteComponentProps } from "react-router";
@@ -29,8 +29,12 @@ function HistoryWatcher({ history, children }: React.PropsWithChildren<RouteComp
     return <>{children}</>;
 }
 
-export function storyRouterDecorator<StoryFnReturnType = unknown>() {
-    return (fn: StoryFn<StoryFnReturnType>, c: StoryContext) => {
-        return <StoryRouter>{fn()}</StoryRouter>;
+export function storyRouterDecorator() {
+    return (Story: React.ComponentType, c: StoryContext) => {
+        return (
+            <StoryRouter>
+                <Story />
+            </StoryRouter>
+        );
     };
 }

--- a/packages/admin/src/stack/Switch.tsx
+++ b/packages/admin/src/stack/Switch.tsx
@@ -110,7 +110,7 @@ const StackSwitchInner: React.RefForwardingComponent<IStackSwitchApi, IProps & I
                 return `${removeTrailingSlash(match.url)}/${payload}/${pageName}${subUrl ? `/${subUrl}` : ""}`;
             }
         },
-        [isInitialPage, match.url],
+        [isInitialPage, match],
     );
 
     const activatePage = React.useCallback(

--- a/packages/admin/src/tabs/RouterTabs.tsx
+++ b/packages/admin/src/tabs/RouterTabs.tsx
@@ -124,7 +124,7 @@ function RouterTabsComponent({
                             } else if (match && !foundFirstMatch) {
                                 foundFirstMatch = true;
                                 return <div className={classes.content}>{child.props.children}</div>;
-                            } else if (!match && child.props.forceRender) {
+                            } else if (child.props.forceRender) {
                                 return <div className={`${classes.content} ${classes.contentHidden}`}>{child.props.children}</div>;
                             } else {
                                 return null;

--- a/packages/admin/src/tabs/RouterTabs.tsx
+++ b/packages/admin/src/tabs/RouterTabs.tsx
@@ -3,7 +3,7 @@ import MuiTab, { TabProps as MuiTabProps } from "@material-ui/core/Tab";
 import Tabs, { TabsProps } from "@material-ui/core/Tabs";
 import { withStyles } from "@material-ui/styles";
 import * as React from "react";
-import { Route, RouteComponentProps, Switch, withRouter } from "react-router-dom";
+import { Route, RouteComponentProps, withRouter } from "react-router-dom";
 
 import { useStackApi } from "../stack/Api";
 import { StackBreadcrumb } from "../stack/Breadcrumb";
@@ -100,33 +100,31 @@ function RouterTabsComponent({
                     }}
                 </Route>
             )}
-            <Switch>
-                {React.Children.map(rearrangedChildren, (child) => {
-                    return React.isValidElement<TabProps>(child) ? (
-                        <Route path={deduplicateSlashesInUrl(`${match.url}/${child.props.path}`)}>
-                            {({ match }) => {
-                                if (match && stackApi && stackSwitchApi) {
-                                    return (
-                                        <StackBreadcrumb
-                                            url={deduplicateSlashesInUrl(`${match.url}/${child.props.path}`)}
-                                            title={child.props.label}
-                                            invisible={true}
-                                        >
-                                            <div className={classes.content}>{child.props.children}</div>
-                                        </StackBreadcrumb>
-                                    );
-                                } else if (match) {
-                                    return <div className={classes.content}>{child.props.children}</div>;
-                                } else if (!match && child.props.forceRender) {
-                                    return <div className={`${classes.content} ${classes.contentHidden}`}>{child.props.children}</div>;
-                                } else {
-                                    return null;
-                                }
-                            }}
-                        </Route>
-                    ) : null;
-                })}
-            </Switch>
+            {React.Children.map(rearrangedChildren, (child) => {
+                return React.isValidElement<TabProps>(child) ? (
+                    <Route path={deduplicateSlashesInUrl(`${match.url}/${child.props.path}`)} exact>
+                        {({ match }) => {
+                            if (match && stackApi && stackSwitchApi) {
+                                return (
+                                    <StackBreadcrumb
+                                        url={deduplicateSlashesInUrl(`${match.url}/${child.props.path}`)}
+                                        title={child.props.label}
+                                        invisible={true}
+                                    >
+                                        <div className={classes.content}>{child.props.children}</div>
+                                    </StackBreadcrumb>
+                                );
+                            } else if (match) {
+                                return <div className={classes.content}>{child.props.children}</div>;
+                            } else if (!match && child.props.forceRender) {
+                                return <div className={`${classes.content} ${classes.contentHidden}`}>{child.props.children}</div>;
+                            } else {
+                                return null;
+                            }
+                        }}
+                    </Route>
+                ) : null;
+            })}
         </div>
     );
 }

--- a/packages/admin/src/tabs/RouterTabs.tsx
+++ b/packages/admin/src/tabs/RouterTabs.tsx
@@ -79,6 +79,12 @@ function RouterTabsComponent({
         shouldShowTabBar = ownSwitchIndex === stackApi.switches.length - (nextSwitchShowsInitialPage ? 2 : 1);
     }
 
+    // used for only rendering the first matching child
+    // note: React Router's Switch can't be used because it
+    // prevents the rendering of more than one child
+    // however we need to render all children if forceRender is true
+    let foundFirstMatch = false;
+
     return (
         <div className={classes.root}>
             {shouldShowTabBar && (
@@ -102,9 +108,10 @@ function RouterTabsComponent({
             )}
             {React.Children.map(rearrangedChildren, (child) => {
                 return React.isValidElement<TabProps>(child) ? (
-                    <Route path={deduplicateSlashesInUrl(`${match.url}/${child.props.path}`)} exact>
+                    <Route path={deduplicateSlashesInUrl(`${match.url}/${child.props.path}`)}>
                         {({ match }) => {
-                            if (match && stackApi && stackSwitchApi) {
+                            if (match && stackApi && stackSwitchApi && !foundFirstMatch) {
+                                foundFirstMatch = true;
                                 return (
                                     <StackBreadcrumb
                                         url={deduplicateSlashesInUrl(`${match.url}/${child.props.path}`)}
@@ -114,7 +121,8 @@ function RouterTabsComponent({
                                         <div className={classes.content}>{child.props.children}</div>
                                     </StackBreadcrumb>
                                 );
-                            } else if (match) {
+                            } else if (match && !foundFirstMatch) {
+                                foundFirstMatch = true;
                                 return <div className={classes.content}>{child.props.children}</div>;
                             } else if (!match && child.props.forceRender) {
                                 return <div className={`${classes.content} ${classes.contentHidden}`}>{child.props.children}</div>;


### PR DESCRIPTION
`RouterTabs` force rendering functionality was broken. 

The reason was that the content was wrapped in a `Switch`. According to React Router Docs

> `<Switch>` is unique in that it renders a route exclusively. In contrast, every `<Route>` that matches the location renders inclusively.
>
> https://v5.reactrouter.com/web/api/Switch

Thus, Switch only renders the first matching route. This means, only the current route is rendered, making the `forceRender` useless by preventing the rendering of other routes.

I removed the `Switch` and mimicked its behavior using a boolean variable. Only the first match is rendered normally, the subsequent matches are not rendered or rendered hidden (depending on `forceRender`).

### Before and After

Console log before this change:

<img width="853" alt="Bildschirmfoto 2022-06-13 um 14 54 27" src="https://user-images.githubusercontent.com/13380047/173360983-87c32055-e13d-4dd5-b6c1-1aaf771c526a.png">

The match function is only called for the first matching route

Console log after this change:

<img width="849" alt="Bildschirmfoto 2022-06-13 um 14 54 50" src="https://user-images.githubusercontent.com/13380047/173361018-836cea23-e483-4a19-99db-6f2f31b5cb2d.png">

The match function is called for every route.

The HTML looks like this:

<img width="559" alt="Bildschirmfoto 2022-06-13 um 15 16 41" src="https://user-images.githubusercontent.com/13380047/173364453-ddb7e191-fbd9-48d6-816e-92b091c4bf7f.png">
