### PR TITLE
Add custom inline styles to RTE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [Next]
+
+## Highlights
+
+-   [RTE] Add custom inline styles (see story "Custom inline styles")
+
 # [2.1.0]
 
 ## Highlights:

--- a/packages/admin-rte/src/core/Controls/FeaturesButtonGroup.tsx
+++ b/packages/admin-rte/src/core/Controls/FeaturesButtonGroup.tsx
@@ -4,6 +4,7 @@ import { MoreHoriz } from "@material-ui/icons";
 import { createStyles, withStyles } from "@material-ui/styles";
 import { Editor } from "draft-js";
 import * as React from "react";
+import { FormattedMessage } from "react-intl";
 
 import { IFeatureConfig } from "../types";
 import ControlButton from "./ControlButton";
@@ -57,7 +58,10 @@ function FeaturesButtonGroup({ features, disabled: globallyDisabled, classes, ed
                 ))}
                 {additionalFeatures.length > 0 && (
                     <div className={classes.buttonWrapper}>
-                        <Tooltip title="More options" placement="top">
+                        <Tooltip
+                            title={<FormattedMessage id="cometAdmin.rte.controls.moreOptionsTooltip" defaultMessage="More options" />}
+                            placement="top"
+                        >
                             <span>
                                 <ControlButton onButtonClick={handleMoreOptionsClick} disabled={globallyDisabled} icon={MoreHoriz} />
                             </span>

--- a/packages/admin-rte/src/core/Controls/FeaturesButtonGroup.tsx
+++ b/packages/admin-rte/src/core/Controls/FeaturesButtonGroup.tsx
@@ -1,6 +1,8 @@
-import { WithStyles } from "@material-ui/core";
+import { ListItemIcon, Menu, MenuItem, WithStyles } from "@material-ui/core";
 import Tooltip from "@material-ui/core/Tooltip";
+import { MoreHoriz } from "@material-ui/icons";
 import { createStyles, withStyles } from "@material-ui/styles";
+import { Editor } from "draft-js";
 import * as React from "react";
 
 import { IFeatureConfig } from "../types";
@@ -9,11 +11,87 @@ import ControlButton from "./ControlButton";
 interface IProps {
     features: IFeatureConfig[];
     disabled?: boolean;
+    editorRef: React.RefObject<Editor>;
+    maxVisible?: number;
 }
 
-function FeaturesButtonGroup({ features, disabled: globallyDisabled, classes }: IProps & WithStyles<typeof styles>) {
+function FeaturesButtonGroup({ features, disabled: globallyDisabled, classes, editorRef, maxVisible }: IProps & WithStyles<typeof styles>) {
+    const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+
+    const handleMoreOptionsClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handleMenuClose = () => {
+        setAnchorEl(null);
+
+        setTimeout(() => {
+            if (editorRef.current) {
+                editorRef.current.focus();
+            }
+        }, 0);
+    };
+
     if (!features.length) {
         return null;
+    }
+
+    if (maxVisible !== undefined) {
+        const visibleFeatures = features.slice(0, maxVisible);
+        const additionalFeatures = features.slice(maxVisible);
+
+        return (
+            <div className={classes.root}>
+                {visibleFeatures.map(({ name, onButtonClick, tooltipText, disabled, ...rest }) => (
+                    <div className={classes.buttonWrapper} key={name}>
+                        {tooltipText ? (
+                            <Tooltip title={tooltipText} placement="top">
+                                <span>
+                                    <ControlButton onButtonClick={onButtonClick} disabled={globallyDisabled || disabled} {...rest} />
+                                </span>
+                            </Tooltip>
+                        ) : (
+                            <ControlButton onButtonClick={onButtonClick} disabled={globallyDisabled || disabled} {...rest} />
+                        )}
+                    </div>
+                ))}
+                {additionalFeatures.length > 0 && (
+                    <div className={classes.buttonWrapper}>
+                        <Tooltip title="More options" placement="top">
+                            <span>
+                                <ControlButton onButtonClick={handleMoreOptionsClick} disabled={globallyDisabled} icon={MoreHoriz} />
+                            </span>
+                        </Tooltip>
+                    </div>
+                )}
+                <Menu open={Boolean(anchorEl)} anchorEl={anchorEl} onClose={handleMenuClose}>
+                    {additionalFeatures.map(({ name, onButtonClick, disabled, selected, label, icon: Icon }) => (
+                        <MenuItem
+                            key={name}
+                            onMouseDown={(event) => {
+                                handleMenuClose();
+
+                                // See https://reactjs.org/docs/legacy-event-pooling.html for more information.
+                                event.persist();
+                                setTimeout(() => {
+                                    onButtonClick?.(event);
+                                }, 0);
+                            }}
+                            disabled={globallyDisabled || disabled}
+                            selected={selected}
+                            className={classes.listItem}
+                        >
+                            {label}
+                            {Icon && (
+                                <ListItemIcon className={classes.listItemIcon}>
+                                    <Icon />
+                                </ListItemIcon>
+                            )}
+                        </MenuItem>
+                    ))}
+                </Menu>
+            </div>
+        );
     }
 
     return (
@@ -35,7 +113,7 @@ function FeaturesButtonGroup({ features, disabled: globallyDisabled, classes }: 
     );
 }
 
-export type RteFeaturesButtonGroupClassKey = "root" | "buttonWrapper";
+export type RteFeaturesButtonGroupClassKey = "root" | "buttonWrapper" | "listItem" | "listItemIcon";
 
 const styles = () => {
     return createStyles<RteFeaturesButtonGroupClassKey, IProps>({
@@ -48,6 +126,12 @@ const styles = () => {
             "&:last-child": {
                 marginRight: 0,
             },
+        },
+        listItem: {
+            justifyContent: "space-between",
+        },
+        listItemIcon: {
+            justifyContent: "flex-end",
         },
     });
 };

--- a/packages/admin-rte/src/core/Controls/FeaturesButtonGroup.tsx
+++ b/packages/admin-rte/src/core/Controls/FeaturesButtonGroup.tsx
@@ -37,70 +37,12 @@ function FeaturesButtonGroup({ features, disabled: globallyDisabled, classes, ed
         return null;
     }
 
-    if (maxVisible !== undefined) {
-        const visibleFeatures = features.slice(0, maxVisible);
-        const additionalFeatures = features.slice(maxVisible);
-
-        return (
-            <div className={classes.root}>
-                {visibleFeatures.map(({ name, onButtonClick, tooltipText, disabled, ...rest }) => (
-                    <div className={classes.buttonWrapper} key={name}>
-                        {tooltipText ? (
-                            <Tooltip title={tooltipText} placement="top">
-                                <span>
-                                    <ControlButton onButtonClick={onButtonClick} disabled={globallyDisabled || disabled} {...rest} />
-                                </span>
-                            </Tooltip>
-                        ) : (
-                            <ControlButton onButtonClick={onButtonClick} disabled={globallyDisabled || disabled} {...rest} />
-                        )}
-                    </div>
-                ))}
-                {additionalFeatures.length > 0 && (
-                    <div className={classes.buttonWrapper}>
-                        <Tooltip
-                            title={<FormattedMessage id="cometAdmin.rte.controls.moreOptionsTooltip" defaultMessage="More options" />}
-                            placement="top"
-                        >
-                            <span>
-                                <ControlButton onButtonClick={handleMoreOptionsClick} disabled={globallyDisabled} icon={MoreHoriz} />
-                            </span>
-                        </Tooltip>
-                    </div>
-                )}
-                <Menu open={Boolean(anchorEl)} anchorEl={anchorEl} onClose={handleMenuClose}>
-                    {additionalFeatures.map(({ name, onButtonClick, disabled, selected, label, icon: Icon }) => (
-                        <MenuItem
-                            key={name}
-                            onMouseDown={(event) => {
-                                handleMenuClose();
-
-                                // See https://reactjs.org/docs/legacy-event-pooling.html for more information.
-                                event.persist();
-                                setTimeout(() => {
-                                    onButtonClick?.(event);
-                                }, 0);
-                            }}
-                            disabled={globallyDisabled || disabled}
-                            selected={selected}
-                            className={classes.listItem}
-                        >
-                            {label}
-                            {Icon && (
-                                <ListItemIcon className={classes.listItemIcon}>
-                                    <Icon />
-                                </ListItemIcon>
-                            )}
-                        </MenuItem>
-                    ))}
-                </Menu>
-            </div>
-        );
-    }
+    const visibleFeatures = maxVisible === undefined ? features : features.slice(0, maxVisible);
+    const additionalFeatures = maxVisible === undefined ? [] : features.slice(maxVisible);
 
     return (
         <div className={classes.root}>
-            {features.map(({ name, onButtonClick, tooltipText, disabled, ...rest }) => (
+            {visibleFeatures.map(({ name, onButtonClick, tooltipText, disabled, ...rest }) => (
                 <div className={classes.buttonWrapper} key={name}>
                     {tooltipText ? (
                         <Tooltip title={tooltipText} placement="top">
@@ -113,6 +55,46 @@ function FeaturesButtonGroup({ features, disabled: globallyDisabled, classes, ed
                     )}
                 </div>
             ))}
+            {additionalFeatures.length > 0 && (
+                <>
+                    <div className={classes.buttonWrapper}>
+                        <Tooltip
+                            title={<FormattedMessage id="cometAdmin.rte.controls.moreOptionsTooltip" defaultMessage="More options" />}
+                            placement="top"
+                        >
+                            <span>
+                                <ControlButton onButtonClick={handleMoreOptionsClick} disabled={globallyDisabled} icon={MoreHoriz} />
+                            </span>
+                        </Tooltip>
+                    </div>
+                    <Menu open={Boolean(anchorEl)} anchorEl={anchorEl} onClose={handleMenuClose}>
+                        {additionalFeatures.map(({ name, onButtonClick, disabled, selected, label, icon: Icon }) => (
+                            <MenuItem
+                                key={name}
+                                onMouseDown={(event) => {
+                                    handleMenuClose();
+
+                                    // See https://reactjs.org/docs/legacy-event-pooling.html for more information.
+                                    event.persist();
+                                    setTimeout(() => {
+                                        onButtonClick?.(event);
+                                    }, 0);
+                                }}
+                                disabled={globallyDisabled || disabled}
+                                selected={selected}
+                                className={classes.listItem}
+                            >
+                                {label}
+                                {Icon && (
+                                    <ListItemIcon className={classes.listItemIcon}>
+                                        <Icon />
+                                    </ListItemIcon>
+                                )}
+                            </MenuItem>
+                        ))}
+                    </Menu>
+                </>
+            )}
         </div>
     );
 }

--- a/packages/admin-rte/src/core/Controls/HistoryContols.tsx
+++ b/packages/admin-rte/src/core/Controls/HistoryContols.tsx
@@ -4,10 +4,10 @@ import { IControlProps } from "../types";
 import FeaturesButtonGroup from "./FeaturesButtonGroup";
 import useHistory from "./useHistory";
 
-export default function HistoryControls({ editorState, setEditorState, options, disabled }: IControlProps) {
+export default function HistoryControls({ editorState, setEditorState, options, disabled, editorRef }: IControlProps) {
     const { features } = useHistory({ editorState, setEditorState, supportedThings: options.supports });
     if (features.length < 1) {
         return null;
     }
-    return <FeaturesButtonGroup features={features} disabled={disabled} />;
+    return <FeaturesButtonGroup features={features} disabled={disabled} editorRef={editorRef} />;
 }

--- a/packages/admin-rte/src/core/Controls/InlineStyleTypeControls.tsx
+++ b/packages/admin-rte/src/core/Controls/InlineStyleTypeControls.tsx
@@ -4,10 +4,16 @@ import { IControlProps } from "../types";
 import FeaturesButtonGroup from "./FeaturesButtonGroup";
 import useInlineStyleType from "./useInlineStyleType";
 
-export default function InlineStyleTypeControls({ editorState, setEditorState, options: { supports: supportedThings }, disabled }: IControlProps) {
-    const { features } = useInlineStyleType({ editorState, setEditorState, supportedThings });
+export default function InlineStyleTypeControls({
+    editorState,
+    setEditorState,
+    options: { supports: supportedThings, customInlineStyles },
+    disabled,
+    editorRef,
+}: IControlProps) {
+    const { features } = useInlineStyleType({ editorState, setEditorState, supportedThings, customInlineStyles, editorRef });
     if (!features) {
         return null;
     }
-    return <FeaturesButtonGroup features={features} disabled={disabled} />;
+    return <FeaturesButtonGroup features={features} disabled={disabled} editorRef={editorRef} maxVisible={2} />;
 }

--- a/packages/admin-rte/src/core/Controls/ListsControls.tsx
+++ b/packages/admin-rte/src/core/Controls/ListsControls.tsx
@@ -15,5 +15,5 @@ export default function ListsControls({
     if (listsFeatures.length < 1) {
         return null;
     }
-    return <FeaturesButtonGroup features={listsFeatures} disabled={disabled} />;
+    return <FeaturesButtonGroup features={listsFeatures} disabled={disabled} editorRef={editorRef} />;
 }

--- a/packages/admin-rte/src/core/Controls/ListsIndentControls.tsx
+++ b/packages/admin-rte/src/core/Controls/ListsIndentControls.tsx
@@ -9,10 +9,11 @@ export default function ListsIndentControls({
     setEditorState,
     options: { supports: supportedThings, listLevelMax },
     disabled,
+    editorRef,
 }: IControlProps) {
     const { features } = useListIndent({ editorState, setEditorState, supportedThings, listLevelMax });
     if (features.length < 1) {
         return null;
     }
-    return <FeaturesButtonGroup features={features} disabled={disabled} />;
+    return <FeaturesButtonGroup features={features} disabled={disabled} editorRef={editorRef} />;
 }

--- a/packages/admin-rte/src/core/Controls/useBlockTypes.tsx
+++ b/packages/admin-rte/src/core/Controls/useBlockTypes.tsx
@@ -7,7 +7,7 @@ import getCurrentBlock from "../utils/getCurrentBlock";
 
 interface IProps {
     editorState: EditorState;
-    setEditorState: (es: EditorState) => void;
+    setEditorState: React.Dispatch<React.SetStateAction<EditorState>>;
     supportedThings: SupportedThings[];
     blocktypeMap: IBlocktypeMap;
     editorRef: React.RefObject<Editor>;

--- a/packages/admin-rte/src/core/Controls/useHistory.ts
+++ b/packages/admin-rte/src/core/Controls/useHistory.ts
@@ -9,7 +9,7 @@ import { IFeatureConfig } from "../types";
 
 interface IProps {
     editorState: EditorState;
-    setEditorState: (es: EditorState) => void;
+    setEditorState: React.Dispatch<React.SetStateAction<EditorState>>;
     supportedThings: SupportedThings[];
 }
 

--- a/packages/admin-rte/src/core/Controls/useListIndent.ts
+++ b/packages/admin-rte/src/core/Controls/useListIndent.ts
@@ -63,7 +63,7 @@ function adjustBlockDepth(type: "increase" | "decrease", editorState: EditorStat
 
 interface IProps {
     editorState: EditorState;
-    setEditorState: (es: EditorState) => void;
+    setEditorState: React.Dispatch<React.SetStateAction<EditorState>>;
     supportedThings: SupportedThings[];
     listLevelMax?: number;
 }

--- a/packages/admin-rte/src/core/Rte.tsx
+++ b/packages/admin-rte/src/core/Rte.tsx
@@ -6,6 +6,7 @@ import { createStyles, withStyles } from "@material-ui/styles";
 import {
     DraftBlockType,
     DraftEditorCommand,
+    DraftStyleMap,
     Editor as DraftJsEditor,
     EditorProps as DraftJsEditorProps,
     EditorState,
@@ -20,7 +21,7 @@ import composeFilterEditorFns from "./filterEditor/composeFilterEditorFns";
 import defaultFilterEditorStateBeforeUpdate from "./filterEditor/default";
 import manageDefaultBlockType from "./filterEditor/manageStandardBlockType";
 import removeBlocksExceedingBlockLimit from "./filterEditor/removeBlocksExceedingBlockLimit";
-import { IBlocktypeMap, ICustomBlockTypeMap_Deprecated, ToolbarButtonComponent } from "./types";
+import { CustomInlineStyles, IBlocktypeMap, ICustomBlockTypeMap_Deprecated, ToolbarButtonComponent } from "./types";
 import createBlockRenderMap from "./utils/createBlockRenderMap";
 import getRteTheme from "./utils/getRteTheme";
 
@@ -64,6 +65,7 @@ export interface IRteOptions {
     standardBlockType: DraftBlockType;
     // @deprecated
     customBlockMap?: ICustomBlockTypeMap_Deprecated;
+    customInlineStyles?: CustomInlineStyles;
 }
 
 export type IOptions = Partial<IRteOptions>;
@@ -254,6 +256,14 @@ const Rte: React.RefForwardingComponent<any, RteProps & WithStyles<typeof styles
     const rootClasses: string[] = [classes.root];
     if (disabled) rootClasses.push(classes.disabled);
 
+    const customStyleMap: DraftStyleMap = { ...styleMap };
+
+    if (options.customInlineStyles) {
+        Object.entries(options.customInlineStyles).forEach(([name, { style }]) => {
+            customStyleMap[name] = style;
+        });
+    }
+
     return (
         <div ref={editorWrapperRef} className={rootClasses.join(" ")}>
             <Controls editorRef={editorRef} editorState={editorState} setEditorState={onChange} options={options} disabled={disabled} />
@@ -268,7 +278,7 @@ const Rte: React.RefForwardingComponent<any, RteProps & WithStyles<typeof styles
                     handleKeyCommand={handleKeyCommand}
                     handleReturn={handleReturn}
                     keyBindingFn={keyBindingFn}
-                    customStyleMap={styleMap}
+                    customStyleMap={customStyleMap}
                     blockRenderMap={blockRenderMap}
                     {...options.draftJsProps}
                 />

--- a/packages/admin-rte/src/core/types.ts
+++ b/packages/admin-rte/src/core/types.ts
@@ -36,13 +36,13 @@ export interface IFeatureConfig<T extends string = string> {
     Icon?: (props: SvgIconProps) => JSX.Element;
 }
 
-type CustomInlineStyleType = "SUP" | "SUB";
+type CustomInlineStyleType = "SUP" | "SUB" | string;
 
 export type InlineStyleType = CustomInlineStyleType | DraftInlineStyleType;
 
 export interface IControlProps {
     editorState: EditorState;
-    setEditorState: (s: EditorState) => void;
+    setEditorState: React.Dispatch<React.SetStateAction<EditorState>>;
     options: IRteOptions;
     editorRef: React.RefObject<Editor>;
     disabled?: boolean;
@@ -65,4 +65,13 @@ interface ICustomBlockType_Deprecated {
  */
 export interface ICustomBlockTypeMap_Deprecated {
     [key: string]: ICustomBlockType_Deprecated;
+}
+
+export interface CustomInlineStyles {
+    [name: string]: {
+        label: React.ReactNode;
+        icon?: (props: SvgIconProps) => JSX.Element;
+        tooltipText?: React.ReactNode;
+        style: React.CSSProperties;
+    };
 }

--- a/packages/admin-stories/src/admin-rte/RteCustomInlineStyles.tsx
+++ b/packages/admin-stories/src/admin-rte/RteCustomInlineStyles.tsx
@@ -13,8 +13,7 @@ const rteOptions: IRteOptions = {
             label: "Highlight!",
             icon: Highlight,
             style: {
-                color: "blue",
-                textDecoration: "underline",
+                backgroundColor: "yellow",
             },
         },
     },

--- a/packages/admin-stories/src/admin-rte/RteCustomInlineStyles.tsx
+++ b/packages/admin-stories/src/admin-rte/RteCustomInlineStyles.tsx
@@ -1,0 +1,46 @@
+import { IRteOptions, IRteRef, makeRteApi, Rte } from "@comet/admin-rte";
+import { Box, Card, CardContent } from "@material-ui/core";
+import { Highlight } from "@material-ui/icons";
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+
+import { PrintEditorState, useAutoFocus } from "./helper";
+
+const rteOptions: IRteOptions = {
+    supports: ["header-one", "header-two", "bold", "italic", "strikethrough", "sub", "sup"],
+    customInlineStyles: {
+        HIGHLIGHT: {
+            label: "Highlight!",
+            icon: Highlight,
+            style: {
+                color: "blue",
+                textDecoration: "underline",
+            },
+        },
+    },
+};
+
+const [useRteApi] = makeRteApi();
+
+function Story() {
+    const { editorState, setEditorState } = useRteApi();
+
+    // focus the editor to see the cursor immediately
+    const editorRef = React.useRef<IRteRef>();
+    useAutoFocus(editorRef);
+
+    return (
+        <>
+            <Box marginBottom={4}>
+                <Card variant="outlined">
+                    <CardContent>
+                        <Rte value={editorState} onChange={setEditorState} ref={editorRef} options={rteOptions} />
+                    </CardContent>
+                </Card>
+            </Box>
+            <PrintEditorState editorState={editorState} />
+        </>
+    );
+}
+
+storiesOf("@comet/admin-rte", module).add("Custom inline styles", () => <Story />);


### PR DESCRIPTION
Adds the option `customInlineStyles`to the RTE options which can be used to define custom styles for the editor. Furthermore, features in the `FeatureButtonGroup` can now be limited using the `maxVisible` props (additional features will be shown in a popup menu).

https://user-images.githubusercontent.com/48853629/173790632-272b52c4-ce57-45ad-933c-00d777c811be.mov


