### PR TITLE
Use NPM v7 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
                   registry-url: "https://registry.npmjs.org"
                   cache: "yarn" # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
 
+            - name: Install NPM 7.x
+              run: npm install -g npm@7
+
             - run: yarn install
 
             - name: Copy schema files


### PR DESCRIPTION
Previously, the CI workflow would use the default NPM version (v6 for Node v14). However, in our projects we are using NPM v7 in combination with Node v14. Consequently, most of our developers are using NPM v7 when using Node v14 on their local machines. We therefore decided to use NPM v7 in the CI workflow as well, as it would cause quite some issues otherwise.